### PR TITLE
Add missing link of `thirdparty_caf_openssl` to `thirdparty_broker`

### DIFF
--- a/libraries/broker-legacy/CMakeLists.txt
+++ b/libraries/broker-legacy/CMakeLists.txt
@@ -318,6 +318,7 @@ function(generateBroker)
     PUBLIC
       zeek_agent_cxx_settings
       thirdparty_actorframework
+      thirdparty_caf_openssl
       thirdparty_sqlite
 
     PRIVATE


### PR DESCRIPTION
`thirdparty_broker` introduces an implicit link dependency on OpenSSL's
libcrypto for any target linking against it. This means libcrypto needs
to be present or built before any of its dependents can be linked.

While even without the direct depedency this seems to have implicitly
happened most of the time when building with Make, before this patch
this did not work with the Ninja generator which detected before the
build that it did not have a rule to build libcrypto.

Adding the explicit link dependency in this patch fixes this issue.

Closes #62.