### PR TITLE
Add file events table to macOS

### DIFF
--- a/components/zeekendpointsecurity/include/zeek/iendpointsecurityconsumer.h
+++ b/components/zeekendpointsecurity/include/zeek/iendpointsecurityconsumer.h
@@ -10,7 +10,7 @@
 #include <unistd.h>
 
 namespace zeek {
-/// \brief Audisp socket consumer (interface)
+/// \brief EndpointSecurity consumer (interface)
 class IEndpointSecurityConsumer {
 public:
   /// \brief Event data
@@ -49,10 +49,13 @@ public:
 
       /// \brief Program path
       std::string path;
+
+      /// \brief File path
+      std::string file_path;
     };
 
     /// \brief Supported event types
-    enum class Type { Fork, Exec };
+    enum class Type { Fork, Exec, Open, Create };
 
     /// \brief Exec event data
     struct ExecEventData final {

--- a/components/zeekendpointsecurity/src/endpointsecurityconsumer.cpp
+++ b/components/zeekendpointsecurity/src/endpointsecurityconsumer.cpp
@@ -127,15 +127,21 @@ void EndpointSecurityConsumer::endpointSecurityCallback(
 
   Status status;
   Event event;
-  if (message.event_type == ES_EVENT_TYPE_NOTIFY_EXEC) {
+  switch (message.event_type) {
+  case ES_EVENT_TYPE_NOTIFY_EXEC:
     status = processExecNotification(event, message_ptr);
-
-  } else if (message.event_type == ES_EVENT_TYPE_NOTIFY_FORK) {
+    break;
+  case ES_EVENT_TYPE_NOTIFY_FORK:
     status = processForkNotification(event, message_ptr);
-  } else if (message.event_type == ES_EVENT_TYPE_NOTIFY_OPEN) {
+    break;
+  case ES_EVENT_TYPE_NOTIFY_OPEN:
     status = processOpenNotification(event, message_ptr);
-  } else if (message.event_type == ES_EVENT_TYPE_NOTIFY_CREATE) {
+    break;
+  case ES_EVENT_TYPE_NOTIFY_CREATE:
     status = processCreateNotification(event, message_ptr);
+    break;
+  default:
+    status = Status::failure("Unhandled event type");
   }
 
   if (!status.succeeded()) {

--- a/components/zeekendpointsecurity/src/endpointsecurityconsumer.h
+++ b/components/zeekendpointsecurity/src/endpointsecurityconsumer.h
@@ -49,5 +49,18 @@ public:
   static Status processForkNotification(Event &event, const void *message_ptr);
 
   friend class IEndpointSecurityConsumer;
+
+  /// \brief File open event handler
+  /// \param event the generated event object
+  /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
+  /// \return A Status object
+  static Status processOpenNotification(Event &event, const void *message_ptr);
+
+  /// \brief File create event handler
+  /// \param event the generated event object
+  /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
+  /// \return A Status object
+  static Status processCreateNotification(Event &event,
+                                          const void *message_ptr);
 };
 } // namespace zeek

--- a/components/zeekendpointsecurity/src/endpointsecurityconsumer.h
+++ b/components/zeekendpointsecurity/src/endpointsecurityconsumer.h
@@ -32,21 +32,21 @@ private:
 public:
   /// \brief Initializes the event header from the given message
   /// \param event_header The event header object to initialize
-  /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
+  /// \param message a reference to an EndpointSecurity es_message_t object
   /// \return A Status object
   static Status initializeEventHeader(Event::Header &event_header,
                                       const es_message_t &message);
 
   /// \brief Process execution event handler
   /// \param event the generated event object
-  /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
+  /// \param message a reference to EndpointSecurity es_message_t object
   /// \return A Status object
   static Status processExecNotification(Event &event,
                                         const es_message_t &message);
 
   /// \brief Process forking event handler
   /// \param event the generated event object
-  /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
+  /// \param message a reference to an EndpointSecurity es_message_t object
   /// \return A Status object
   static Status processForkNotification(Event &event,
                                         const es_message_t &message);
@@ -55,14 +55,14 @@ public:
 
   /// \brief File open event handler
   /// \param event the generated event object
-  /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
+  /// \param message a reference to an EndpointSecurity es_message_t object
   /// \return A Status object
   static Status processOpenNotification(Event &event,
                                         const es_message_t &message);
 
   /// \brief File create event handler
   /// \param event the generated event object
-  /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
+  /// \param message a reference to an EndpointSecurity es_message_t object
   /// \return A Status object
   static Status processCreateNotification(Event &event,
                                           const es_message_t &message);

--- a/components/zeekendpointsecurity/src/endpointsecurityconsumer.h
+++ b/components/zeekendpointsecurity/src/endpointsecurityconsumer.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <vector>
 
+#include <EndpointSecurity/EndpointSecurity.h>
 #include <zeek/iendpointsecurityconsumer.h>
 
 namespace zeek {
@@ -26,7 +27,7 @@ private:
                            IZeekConfiguration &configuration);
 
   /// \brief Event callback used by EndpointSecurity
-  void endpointSecurityCallback(const void *message_ptr);
+  void endpointSecurityCallback(const es_message_t &message);
 
 public:
   /// \brief Initializes the event header from the given message
@@ -34,19 +35,21 @@ public:
   /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
   /// \return A Status object
   static Status initializeEventHeader(Event::Header &event_header,
-                                      const void *message_ptr);
+                                      const es_message_t &message);
 
   /// \brief Process execution event handler
   /// \param event the generated event object
   /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
   /// \return A Status object
-  static Status processExecNotification(Event &event, const void *message_ptr);
+  static Status processExecNotification(Event &event,
+                                        const es_message_t &message);
 
   /// \brief Process forking event handler
   /// \param event the generated event object
   /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
   /// \return A Status object
-  static Status processForkNotification(Event &event, const void *message_ptr);
+  static Status processForkNotification(Event &event,
+                                        const es_message_t &message);
 
   friend class IEndpointSecurityConsumer;
 
@@ -54,13 +57,14 @@ public:
   /// \param event the generated event object
   /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
   /// \return A Status object
-  static Status processOpenNotification(Event &event, const void *message_ptr);
+  static Status processOpenNotification(Event &event,
+                                        const es_message_t &message);
 
   /// \brief File create event handler
   /// \param event the generated event object
   /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
   /// \return A Status object
   static Status processCreateNotification(Event &event,
-                                          const void *message_ptr);
+                                          const es_message_t &message);
 };
 } // namespace zeek

--- a/components/zeekendpointsecurity/tests/endpointsecurityconsumer.cpp
+++ b/components/zeekendpointsecurity/tests/endpointsecurityconsumer.cpp
@@ -5,10 +5,10 @@
 #include <catch2/catch.hpp>
 
 #include <EndpointSecurity/EndpointSecurity.h>
-#include <bsm/libbsm.h>
 
 namespace zeek {
-TEST_CASE("Event header initialization", "[ZeekEndpointConsumer]") {
+TEST_CASE("Event header initialization for Exec Event",
+          "[ZeekEndpointConsumer]") {
   es_process_t process = {};
   process.ppid = 10U;
   process.original_ppid = 11U;
@@ -59,5 +59,200 @@ TEST_CASE("Event header initialization", "[ZeekEndpointConsumer]") {
   REQUIRE(header.team_id == kDummyTeamIdentifier);
   REQUIRE(header.path == kDummyPath);
   REQUIRE(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+}
+
+TEST_CASE("Event header initialization for Open event",
+          "[ZeekEndpointConsumer]") {
+  es_process_t process = {};
+  process.ppid = 10U;
+  process.original_ppid = 11U;
+
+  for (auto i = 0U; i < 8U; ++i) {
+    process.audit_token.val[i] = 0xF0U + i;
+  }
+
+  process.is_platform_binary = 1U;
+
+  for (auto i = 0U; i < sizeof(process.cdhash); ++i) {
+    process.cdhash[i] = 0xA0U + i;
+  }
+
+  const char *kDummySigningIdentifier = "SigningID";
+  process.signing_id.data = kDummySigningIdentifier;
+  process.signing_id.length = std::strlen(kDummySigningIdentifier);
+
+  const char *kDummyTeamIdentifier = "TeamID";
+  process.team_id.data = kDummyTeamIdentifier;
+  process.team_id.length = std::strlen(kDummyTeamIdentifier);
+
+  const char *kDummyPath = "/path/to/application";
+  es_file_t executable = {};
+  executable.path.data = kDummyPath;
+  executable.path.length = std::strlen(kDummyPath);
+
+  process.executable = &executable;
+
+  es_message_t es_message = {};
+  es_message.event_type = ES_EVENT_TYPE_NOTIFY_OPEN;
+  es_message.process = &process;
+
+  const char *kDummyFilePath = "/path/to/file";
+  es_file_t file = {};
+  file.path.data = kDummyFilePath;
+  file.path.length = std::strlen(kDummyFilePath);
+
+  es_message.event.open.file = &file;
+
+  IEndpointSecurityConsumer::Event::Header header;
+  auto status =
+      EndpointSecurityConsumer::initializeEventHeader(header, es_message);
+
+  REQUIRE(status.succeeded());
+
+  REQUIRE(header.timestamp != 0U);
+  REQUIRE(header.parent_process_id == 10U);
+  REQUIRE(header.orig_parent_process_id == 11U);
+  REQUIRE(header.process_id == 245U);
+  REQUIRE(header.user_id == 241U);
+  REQUIRE(header.group_id == 242U);
+  REQUIRE(header.platform_binary == 1U);
+  REQUIRE(header.signing_id == kDummySigningIdentifier);
+  REQUIRE(header.team_id == kDummyTeamIdentifier);
+  REQUIRE(header.path == kDummyPath);
+  REQUIRE(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+  REQUIRE(header.file_path == kDummyFilePath);
+}
+
+TEST_CASE("Event header initialization for Create event with existing path",
+          "[ZeekEndpointConsumer]") {
+  es_process_t process = {};
+  process.ppid = 10U;
+  process.original_ppid = 11U;
+
+  for (auto i = 0U; i < 8U; ++i) {
+    process.audit_token.val[i] = 0xF0U + i;
+  }
+
+  process.is_platform_binary = 1U;
+
+  for (auto i = 0U; i < sizeof(process.cdhash); ++i) {
+    process.cdhash[i] = 0xA0U + i;
+  }
+
+  const char *kDummySigningIdentifier = "SigningID";
+  process.signing_id.data = kDummySigningIdentifier;
+  process.signing_id.length = std::strlen(kDummySigningIdentifier);
+
+  const char *kDummyTeamIdentifier = "TeamID";
+  process.team_id.data = kDummyTeamIdentifier;
+  process.team_id.length = std::strlen(kDummyTeamIdentifier);
+
+  const char *kDummyPath = "/path/to/application";
+  es_file_t executable = {};
+  executable.path.data = kDummyPath;
+  executable.path.length = std::strlen(kDummyPath);
+
+  process.executable = &executable;
+
+  es_message_t es_message = {};
+  es_message.event_type = ES_EVENT_TYPE_NOTIFY_CREATE;
+  es_message.event.create.destination_type = ES_DESTINATION_TYPE_NEW_PATH;
+  es_message.process = &process;
+
+  const char *kDummyFilePath = "/path/to/file";
+
+  const char *kDummyDir = "/path/to";
+  es_file_t newPathDir = {};
+  newPathDir.path.data = kDummyDir;
+  newPathDir.path.length = std::strlen(kDummyDir);
+
+  es_message.event.create.destination.new_path.dir = &newPathDir;
+
+  const char *kDummyFilename = "file";
+  es_message.event.create.destination.new_path.filename.data = kDummyFilename;
+  es_message.event.create.destination.new_path.filename.length =
+      std::strlen(kDummyFilename);
+
+  IEndpointSecurityConsumer::Event::Header header;
+  auto status =
+      EndpointSecurityConsumer::initializeEventHeader(header, es_message);
+
+  REQUIRE(status.succeeded());
+
+  REQUIRE(header.timestamp != 0U);
+  REQUIRE(header.parent_process_id == 10U);
+  REQUIRE(header.orig_parent_process_id == 11U);
+  REQUIRE(header.process_id == 245U);
+  REQUIRE(header.user_id == 241U);
+  REQUIRE(header.group_id == 242U);
+  REQUIRE(header.platform_binary == 1U);
+  REQUIRE(header.signing_id == kDummySigningIdentifier);
+  REQUIRE(header.team_id == kDummyTeamIdentifier);
+  REQUIRE(header.path == kDummyPath);
+  REQUIRE(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+  REQUIRE(header.file_path == kDummyFilePath);
+}
+
+TEST_CASE("Event header initialization for Create event with new path",
+          "[ZeekEndpointConsumer]") {
+  es_process_t process = {};
+  process.ppid = 10U;
+  process.original_ppid = 11U;
+
+  for (auto i = 0U; i < 8U; ++i) {
+    process.audit_token.val[i] = 0xF0U + i;
+  }
+
+  process.is_platform_binary = 1U;
+
+  for (auto i = 0U; i < sizeof(process.cdhash); ++i) {
+    process.cdhash[i] = 0xA0U + i;
+  }
+
+  const char *kDummySigningIdentifier = "SigningID";
+  process.signing_id.data = kDummySigningIdentifier;
+  process.signing_id.length = std::strlen(kDummySigningIdentifier);
+
+  const char *kDummyTeamIdentifier = "TeamID";
+  process.team_id.data = kDummyTeamIdentifier;
+  process.team_id.length = std::strlen(kDummyTeamIdentifier);
+
+  const char *kDummyPath = "/path/to/application";
+  es_file_t executable = {};
+  executable.path.data = kDummyPath;
+  executable.path.length = std::strlen(kDummyPath);
+
+  process.executable = &executable;
+
+  es_message_t es_message = {};
+  es_message.event_type = ES_EVENT_TYPE_NOTIFY_CREATE;
+  es_message.event.create.destination_type = ES_DESTINATION_TYPE_EXISTING_FILE;
+  es_message.process = &process;
+
+  const char *kDummyFilePath = "/path/to/file";
+  es_file_t existing_file = {};
+  existing_file.path.data = kDummyFilePath;
+  existing_file.path.length = std::strlen(kDummyFilePath);
+
+  es_message.event.create.destination.existing_file = &existing_file;
+
+  IEndpointSecurityConsumer::Event::Header header;
+  auto status =
+      EndpointSecurityConsumer::initializeEventHeader(header, es_message);
+
+  REQUIRE(status.succeeded());
+
+  REQUIRE(header.timestamp != 0U);
+  REQUIRE(header.parent_process_id == 10U);
+  REQUIRE(header.orig_parent_process_id == 11U);
+  REQUIRE(header.process_id == 245U);
+  REQUIRE(header.user_id == 241U);
+  REQUIRE(header.group_id == 242U);
+  REQUIRE(header.platform_binary == 1U);
+  REQUIRE(header.signing_id == kDummySigningIdentifier);
+  REQUIRE(header.team_id == kDummyTeamIdentifier);
+  REQUIRE(header.path == kDummyPath);
+  REQUIRE(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+  REQUIRE(header.file_path == kDummyFilePath);
 }
 } // namespace zeek

--- a/components/zeekendpointsecurity/tests/endpointsecurityconsumer.cpp
+++ b/components/zeekendpointsecurity/tests/endpointsecurityconsumer.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Event header initialization", "[ZeekEndpointConsumer]") {
 
   IEndpointSecurityConsumer::Event::Header header;
   auto status =
-      EndpointSecurityConsumer::initializeEventHeader(header, &es_message);
+      EndpointSecurityConsumer::initializeEventHeader(header, es_message);
 
   REQUIRE(status.succeeded());
 

--- a/components/zeekendpointsecurity/tests/endpointsecurityconsumer.cpp
+++ b/components/zeekendpointsecurity/tests/endpointsecurityconsumer.cpp
@@ -48,17 +48,17 @@ TEST_CASE("Event header initialization for Exec Event",
 
   REQUIRE(status.succeeded());
 
-  REQUIRE(header.timestamp != 0U);
-  REQUIRE(header.parent_process_id == 10U);
-  REQUIRE(header.orig_parent_process_id == 11U);
-  REQUIRE(header.process_id == 245U);
-  REQUIRE(header.user_id == 241U);
-  REQUIRE(header.group_id == 242U);
-  REQUIRE(header.platform_binary == 1U);
-  REQUIRE(header.signing_id == kDummySigningIdentifier);
-  REQUIRE(header.team_id == kDummyTeamIdentifier);
-  REQUIRE(header.path == kDummyPath);
-  REQUIRE(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+  CHECK(header.timestamp != 0U);
+  CHECK(header.parent_process_id == 10U);
+  CHECK(header.orig_parent_process_id == 11U);
+  CHECK(header.process_id == 245U);
+  CHECK(header.user_id == 241U);
+  CHECK(header.group_id == 242U);
+  CHECK(header.platform_binary == 1U);
+  CHECK(header.signing_id == kDummySigningIdentifier);
+  CHECK(header.team_id == kDummyTeamIdentifier);
+  CHECK(header.path == kDummyPath);
+  CHECK(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
 }
 
 TEST_CASE("Event header initialization for Open event",
@@ -109,18 +109,18 @@ TEST_CASE("Event header initialization for Open event",
 
   REQUIRE(status.succeeded());
 
-  REQUIRE(header.timestamp != 0U);
-  REQUIRE(header.parent_process_id == 10U);
-  REQUIRE(header.orig_parent_process_id == 11U);
-  REQUIRE(header.process_id == 245U);
-  REQUIRE(header.user_id == 241U);
-  REQUIRE(header.group_id == 242U);
-  REQUIRE(header.platform_binary == 1U);
-  REQUIRE(header.signing_id == kDummySigningIdentifier);
-  REQUIRE(header.team_id == kDummyTeamIdentifier);
-  REQUIRE(header.path == kDummyPath);
-  REQUIRE(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
-  REQUIRE(header.file_path == kDummyFilePath);
+  CHECK(header.timestamp != 0U);
+  CHECK(header.parent_process_id == 10U);
+  CHECK(header.orig_parent_process_id == 11U);
+  CHECK(header.process_id == 245U);
+  CHECK(header.user_id == 241U);
+  CHECK(header.group_id == 242U);
+  CHECK(header.platform_binary == 1U);
+  CHECK(header.signing_id == kDummySigningIdentifier);
+  CHECK(header.team_id == kDummyTeamIdentifier);
+  CHECK(header.path == kDummyPath);
+  CHECK(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+  CHECK(header.file_path == kDummyFilePath);
 }
 
 TEST_CASE("Event header initialization for Create event with existing path",
@@ -179,18 +179,18 @@ TEST_CASE("Event header initialization for Create event with existing path",
 
   REQUIRE(status.succeeded());
 
-  REQUIRE(header.timestamp != 0U);
-  REQUIRE(header.parent_process_id == 10U);
-  REQUIRE(header.orig_parent_process_id == 11U);
-  REQUIRE(header.process_id == 245U);
-  REQUIRE(header.user_id == 241U);
-  REQUIRE(header.group_id == 242U);
-  REQUIRE(header.platform_binary == 1U);
-  REQUIRE(header.signing_id == kDummySigningIdentifier);
-  REQUIRE(header.team_id == kDummyTeamIdentifier);
-  REQUIRE(header.path == kDummyPath);
-  REQUIRE(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
-  REQUIRE(header.file_path == kDummyFilePath);
+  CHECK(header.timestamp != 0U);
+  CHECK(header.parent_process_id == 10U);
+  CHECK(header.orig_parent_process_id == 11U);
+  CHECK(header.process_id == 245U);
+  CHECK(header.user_id == 241U);
+  CHECK(header.group_id == 242U);
+  CHECK(header.platform_binary == 1U);
+  CHECK(header.signing_id == kDummySigningIdentifier);
+  CHECK(header.team_id == kDummyTeamIdentifier);
+  CHECK(header.path == kDummyPath);
+  CHECK(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+  CHECK(header.file_path == kDummyFilePath);
 }
 
 TEST_CASE("Event header initialization for Create event with new path",
@@ -242,17 +242,17 @@ TEST_CASE("Event header initialization for Create event with new path",
 
   REQUIRE(status.succeeded());
 
-  REQUIRE(header.timestamp != 0U);
-  REQUIRE(header.parent_process_id == 10U);
-  REQUIRE(header.orig_parent_process_id == 11U);
-  REQUIRE(header.process_id == 245U);
-  REQUIRE(header.user_id == 241U);
-  REQUIRE(header.group_id == 242U);
-  REQUIRE(header.platform_binary == 1U);
-  REQUIRE(header.signing_id == kDummySigningIdentifier);
-  REQUIRE(header.team_id == kDummyTeamIdentifier);
-  REQUIRE(header.path == kDummyPath);
-  REQUIRE(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
-  REQUIRE(header.file_path == kDummyFilePath);
+  CHECK(header.timestamp != 0U);
+  CHECK(header.parent_process_id == 10U);
+  CHECK(header.orig_parent_process_id == 11U);
+  CHECK(header.process_id == 245U);
+  CHECK(header.user_id == 241U);
+  CHECK(header.group_id == 242U);
+  CHECK(header.platform_binary == 1U);
+  CHECK(header.signing_id == kDummySigningIdentifier);
+  CHECK(header.team_id == kDummyTeamIdentifier);
+  CHECK(header.path == kDummyPath);
+  CHECK(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+  CHECK(header.file_path == kDummyFilePath);
 }
 } // namespace zeek

--- a/tables/endpointsecurity/CMakeLists.txt
+++ b/tables/endpointsecurity/CMakeLists.txt
@@ -8,6 +8,9 @@ function(zeekAgentTablesEndpointSecurity)
     src/processeventstableplugin.h
     src/processeventstableplugin.cpp
 
+    src/fileeventstableplugin.h
+    src/fileeventstableplugin.cpp
+
     src/endpointsecurityservice.h
     src/endpointsecurityservice.cpp
   )
@@ -36,6 +39,7 @@ function(zeekAgentTablesEndpointSecurity)
     SOURCES
       tests/main.cpp
       tests/processeventstableplugin.cpp
+      tests/fileeventstableplugin.cpp
   )
 endfunction()
 

--- a/tables/endpointsecurity/src/endpointsecurityservice.cpp
+++ b/tables/endpointsecurity/src/endpointsecurityservice.cpp
@@ -1,4 +1,5 @@
 #include "endpointsecurityservice.h"
+#include "fileeventstableplugin.h"
 #include "processeventstableplugin.h"
 
 #include <algorithm>
@@ -27,6 +28,7 @@ struct EndpointSecurityService::PrivateData final {
   IEndpointSecurityConsumer::Ref endpoint_sec_consumer;
 
   IVirtualTable::Ref process_events_table;
+  IVirtualTable::Ref file_events_table;
 };
 
 EndpointSecurityService::~EndpointSecurityService() {
@@ -36,8 +38,13 @@ EndpointSecurityService::~EndpointSecurityService() {
 
   auto status =
       d->virtual_database.unregisterTable(d->process_events_table->name());
-
   assert(status.succeeded() && "Failed to unregister the process_events table");
+
+  if (!d->file_events_table) {
+    return;
+  }
+  status = d->virtual_database.unregisterTable(d->file_events_table->name());
+  assert(status.succeeded() && "Failed to unregister the file_events table");
 }
 
 const std::string &EndpointSecurityService::name() const {
@@ -51,10 +58,18 @@ Status EndpointSecurityService::exec(std::atomic_bool &terminate) {
       continue;
     }
 
+    if (!d->file_events_table) {
+      std::this_thread::sleep_for(std::chrono::seconds(1U));
+      continue;
+    }
     auto &process_events_table_impl =
         *static_cast<ProcessEventsTablePlugin *>(d->process_events_table.get());
 
+    auto &file_events_table_impl =
+        *static_cast<FileEventsTablePlugin *>(d->file_events_table.get());
+
     IEndpointSecurityConsumer::EventList event_list;
+
     d->endpoint_sec_consumer->getEvents(event_list);
 
     if (event_list.empty()) {
@@ -66,6 +81,14 @@ Status EndpointSecurityService::exec(std::atomic_bool &terminate) {
       d->logger.logMessage(
           IZeekLogger::Severity::Error,
           "The process_events table failed to process some events: " +
+              status.message());
+    }
+
+    status = file_events_table_impl.processEvents(event_list);
+    if (!status.succeeded()) {
+      d->logger.logMessage(
+          IZeekLogger::Severity::Error,
+          "The file_events table failed to process some events: " +
               status.message());
     }
   }
@@ -82,10 +105,11 @@ EndpointSecurityService::EndpointSecurityService(
                                                   logger, configuration);
 
   if (!status.succeeded()) {
-    d->logger.logMessage(IZeekLogger::Severity::Error,
-                         "Failed to connect to the EndpointSecurity API. The "
-                         "process_events table will not be enabled. Error: " +
-                             status.message());
+    d->logger.logMessage(
+        IZeekLogger::Severity::Error,
+        "Failed to connect to the EndpointSecurity API. The "
+        "process_events and file_events tables will not be enabled. Error: " +
+            status.message());
 
     return;
   }
@@ -97,6 +121,17 @@ EndpointSecurityService::EndpointSecurityService(
   }
 
   status = d->virtual_database.registerTable(d->process_events_table);
+  if (!status.succeeded()) {
+    throw status;
+  }
+
+  status = FileEventsTablePlugin::create(d->file_events_table, configuration,
+                                         logger);
+  if (!status.succeeded()) {
+    throw status;
+  }
+
+  status = d->virtual_database.registerTable(d->file_events_table);
   if (!status.succeeded()) {
     throw status;
   }

--- a/tables/endpointsecurity/src/fileeventstableplugin.cpp
+++ b/tables/endpointsecurity/src/fileeventstableplugin.cpp
@@ -92,19 +92,21 @@ Status FileEventsTablePlugin::processEvents(
 
   if (d->row_list.size() > d->max_queued_row_count) {
 
-    auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
+    std::lock_guard<std::mutex> lock(d->row_list_mutex);
+    
+    if (d->row_list.size() > d->max_queued_row_count) {
+      auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
 
-    d->logger.logMessage(IZeekLogger::Severity::Warning,
-                         "file_events: Dropping " +
-                             std::to_string(rows_to_remove) +
-                             " rows (max row count is set to " +
-                             std::to_string(d->max_queued_row_count) + ")");
+      d->logger.logMessage(IZeekLogger::Severity::Warning,
+                           "file_events: Dropping " +
+                               std::to_string(rows_to_remove) +
+                               " rows (max row count is set to " +
+                               std::to_string(d->max_queued_row_count) + ")");
 
-    {
-      std::lock_guard<std::mutex> lock(d->row_list_mutex);
       d->row_list.erase(d->row_list.begin(),
                         std::next(d->row_list.begin(), rows_to_remove));
     }
+
   }
 
   return Status::success();

--- a/tables/endpointsecurity/src/fileeventstableplugin.cpp
+++ b/tables/endpointsecurity/src/fileeventstableplugin.cpp
@@ -1,6 +1,7 @@
 #include "fileeventstableplugin.h"
 
 #include <chrono>
+#include <limits>
 #include <mutex>
 
 namespace zeek {
@@ -72,7 +73,6 @@ Status FileEventsTablePlugin::generateRowList(RowList &row_list) {
 
 Status FileEventsTablePlugin::processEvents(
     const IEndpointSecurityConsumer::EventList &event_list) {
-  RowList generated_row_list;
 
   for (const auto &event : event_list) {
     Row row;
@@ -83,26 +83,25 @@ Status FileEventsTablePlugin::processEvents(
     }
 
     if (!row.empty()) {
-      generated_row_list.push_back(std::move(row));
+      {
+        std::lock_guard<std::mutex> lock(d->row_list_mutex);
+        d->row_list.push_back(row);
+      }
     }
   }
 
-  {
-    std::lock_guard<std::mutex> lock(d->row_list_mutex);
+  if (d->row_list.size() > d->max_queued_row_count) {
 
-    d->row_list.insert(d->row_list.end(),
-                       std::make_move_iterator(generated_row_list.begin()),
-                       std::make_move_iterator(generated_row_list.end()));
+    auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
 
-    if (d->row_list.size() > d->max_queued_row_count) {
-      auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
+    d->logger.logMessage(IZeekLogger::Severity::Warning,
+                         "file_events: Dropping " +
+                             std::to_string(rows_to_remove) +
+                             " rows (max row count is set to " +
+                             std::to_string(d->max_queued_row_count) + ")");
 
-      d->logger.logMessage(IZeekLogger::Severity::Warning,
-                           "file_events: Dropping " +
-                               std::to_string(rows_to_remove) +
-                               " rows (max row count is set to " +
-                               std::to_string(d->max_queued_row_count));
-
+    {
+      std::lock_guard<std::mutex> lock(d->row_list_mutex);
       d->row_list.erase(d->row_list.begin(),
                         std::next(d->row_list.begin(), rows_to_remove));
     }
@@ -137,6 +136,8 @@ Status FileEventsTablePlugin::generateRow(
     return Status::success();
   }
   const auto &header = event.header;
+  assert((header.timestamp <= std::numeric_limits<int64_t>::max()) &&
+         "Failed to cast timestamp to int64_t");
   row["timestamp"] = static_cast<std::int64_t>(header.timestamp);
   row["parent_process_id"] =
       static_cast<std::int64_t>(header.parent_process_id);

--- a/tables/endpointsecurity/src/fileeventstableplugin.cpp
+++ b/tables/endpointsecurity/src/fileeventstableplugin.cpp
@@ -19,7 +19,6 @@ struct FileEventsTablePlugin::PrivateData final {
 Status FileEventsTablePlugin::create(Ref &obj,
                                      IZeekConfiguration &configuration,
                                      IZeekLogger &logger) {
-  obj.reset();
 
   try {
     obj.reset(new FileEventsTablePlugin(configuration, logger));

--- a/tables/endpointsecurity/src/fileeventstableplugin.cpp
+++ b/tables/endpointsecurity/src/fileeventstableplugin.cpp
@@ -114,7 +114,6 @@ Status FileEventsTablePlugin::processEvents(
 FileEventsTablePlugin::FileEventsTablePlugin(IZeekConfiguration &configuration,
                                              IZeekLogger &logger)
     : d(new PrivateData(configuration, logger)) {
-
   d->max_queued_row_count = d->configuration.maxQueuedRowCount();
 }
 
@@ -152,7 +151,7 @@ Status FileEventsTablePlugin::generateRow(
   row["cdhash"] = header.cdhash;
   row["path"] = header.path;
   row["file_path"] = header.file_path;
-  row["type"] = action;
+  row["type"] = std::move(action);
 
   return Status::success();
 }

--- a/tables/endpointsecurity/src/fileeventstableplugin.cpp
+++ b/tables/endpointsecurity/src/fileeventstableplugin.cpp
@@ -23,8 +23,7 @@ Status FileEventsTablePlugin::create(Ref &obj,
   obj.reset();
 
   try {
-    auto ptr = new FileEventsTablePlugin(configuration, logger);
-    obj.reset(ptr);
+    obj.reset(new FileEventsTablePlugin(configuration, logger));
 
     return Status::success();
 
@@ -146,7 +145,8 @@ Status FileEventsTablePlugin::generateRow(
     action = "create";
     break;
 
-  default:
+  case IEndpointSecurityConsumer::Event::Type::Exec:
+  case IEndpointSecurityConsumer::Event::Type::Fork:
     return Status::success();
   }
   const auto &header = event.header;

--- a/tables/endpointsecurity/src/fileeventstableplugin.cpp
+++ b/tables/endpointsecurity/src/fileeventstableplugin.cpp
@@ -3,7 +3,6 @@
 #include <chrono>
 #include <mutex>
 
-
 namespace zeek {
 struct FileEventsTablePlugin::PrivateData final {
   PrivateData(IZeekConfiguration &configuration_, IZeekLogger &logger_)
@@ -44,23 +43,21 @@ const std::string &FileEventsTablePlugin::name() const {
 }
 
 const FileEventsTablePlugin::Schema &FileEventsTablePlugin::schema() const {
-  // clang-format off
+
   static const Schema kTableSchema = {
-    { "timestamp", IVirtualTable::ColumnType::Integer },
-    { "type", IVirtualTable::ColumnType::String },
-    { "parent_process_id", IVirtualTable::ColumnType::Integer },
-    { "orig_parent_process_id", IVirtualTable::ColumnType::Integer },
-    { "process_id", IVirtualTable::ColumnType::Integer },
-    { "user_id", IVirtualTable::ColumnType::Integer },
-    { "group_id", IVirtualTable::ColumnType::Integer },
-    { "platform_binary", IVirtualTable::ColumnType::Integer },
-    { "signing_id", IVirtualTable::ColumnType::String },
-    { "team_id", IVirtualTable::ColumnType::String },
-    { "cdhash", IVirtualTable::ColumnType::String },
-    { "path", IVirtualTable::ColumnType::String },
-    { "file_path", IVirtualTable::ColumnType::String }
-  };
-  // clang-format on
+      {"timestamp", IVirtualTable::ColumnType::Integer},
+      {"type", IVirtualTable::ColumnType::String},
+      {"parent_process_id", IVirtualTable::ColumnType::Integer},
+      {"orig_parent_process_id", IVirtualTable::ColumnType::Integer},
+      {"process_id", IVirtualTable::ColumnType::Integer},
+      {"user_id", IVirtualTable::ColumnType::Integer},
+      {"group_id", IVirtualTable::ColumnType::Integer},
+      {"platform_binary", IVirtualTable::ColumnType::Integer},
+      {"signing_id", IVirtualTable::ColumnType::String},
+      {"team_id", IVirtualTable::ColumnType::String},
+      {"cdhash", IVirtualTable::ColumnType::String},
+      {"path", IVirtualTable::ColumnType::String},
+      {"file_path", IVirtualTable::ColumnType::String}};
 
   return kTableSchema;
 }
@@ -94,13 +91,9 @@ Status FileEventsTablePlugin::processEvents(
   {
     std::lock_guard<std::mutex> lock(d->row_list_mutex);
 
-    // clang-format off
-    d->row_list.insert(
-      d->row_list.end(),
-      std::make_move_iterator(generated_row_list.begin()),
-      std::make_move_iterator(generated_row_list.end())
-    );
-    // clang-format on
+    d->row_list.insert(d->row_list.end(),
+                       std::make_move_iterator(generated_row_list.begin()),
+                       std::make_move_iterator(generated_row_list.end()));
 
     if (d->row_list.size() > d->max_queued_row_count) {
       auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
@@ -111,12 +104,8 @@ Status FileEventsTablePlugin::processEvents(
                                " rows (max row count is set to " +
                                std::to_string(d->max_queued_row_count));
 
-      // clang-format off
-      d->row_list.erase(
-        d->row_list.begin(),
-        std::next(d->row_list.begin(), rows_to_remove)
-      );
-      // clang-format on
+      d->row_list.erase(d->row_list.begin(),
+                        std::next(d->row_list.begin(), rows_to_remove));
     }
   }
 

--- a/tables/endpointsecurity/src/fileeventstableplugin.h
+++ b/tables/endpointsecurity/src/fileeventstableplugin.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <zeek/iendpointsecurityconsumer.h>
+#include <zeek/ivirtualtable.h>
+#include <zeek/izeekconfiguration.h>
+#include <zeek/izeeklogger.h>
+
+namespace zeek {
+/// \brief Provides the file_events table
+class FileEventsTablePlugin final : public IVirtualTable {
+  struct PrivateData;
+  std::unique_ptr<PrivateData> d;
+
+public:
+  /// \brief Factory method
+  /// \param obj Where the created object is stored
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  /// \return A Status object
+  static Status create(Ref &obj, IZeekConfiguration &configuration,
+                       IZeekLogger &logger);
+
+  /// \brief Destructor
+  virtual ~FileEventsTablePlugin() override;
+
+  /// \return The table name
+  virtual const std::string &name() const override;
+
+  /// \return The table schema
+  virtual const Schema &schema() const override;
+
+  /// \brief Generates the row list containing the fields from the given
+  ///        configuration object
+  /// \param row_list Where the generated rows are stored
+  /// \return A Status object
+  virtual Status generateRowList(RowList &row_list) override;
+
+  /// \brief Processes the specified event list, generating new rows
+  /// \param event_list A list of EndpointSecurity events
+  /// \return A Status object
+  Status processEvents(const IEndpointSecurityConsumer::EventList &event_list);
+
+protected:
+  /// \brief Constructor
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  FileEventsTablePlugin(IZeekConfiguration &configuration, IZeekLogger &logger);
+
+public:
+  /// \brief Generates a single row from the given EndpointSecurity event
+  /// \param event a single EndpointSecurity event
+  /// \return A Status object
+  static Status generateRow(Row &row,
+                            const IEndpointSecurityConsumer::Event &event);
+};
+} // namespace zeek

--- a/tables/endpointsecurity/src/processeventstableplugin.cpp
+++ b/tables/endpointsecurity/src/processeventstableplugin.cpp
@@ -19,7 +19,6 @@ struct ProcessEventsTablePlugin::PrivateData final {
 Status ProcessEventsTablePlugin::create(Ref &obj,
                                         IZeekConfiguration &configuration,
                                         IZeekLogger &logger) {
-  obj.reset();
 
   try {
     auto ptr = new ProcessEventsTablePlugin(configuration, logger);

--- a/tables/endpointsecurity/src/processeventstableplugin.cpp
+++ b/tables/endpointsecurity/src/processeventstableplugin.cpp
@@ -136,7 +136,8 @@ Status ProcessEventsTablePlugin::generateRow(
     action = "fork";
     break;
 
-  default:
+  case IEndpointSecurityConsumer::Event::Type::Open:
+  case IEndpointSecurityConsumer::Event::Type::Create:
     return Status::success();
   }
 
@@ -159,7 +160,7 @@ Status ProcessEventsTablePlugin::generateRow(
   row["path"] = header.path;
 
   if (event.type == IEndpointSecurityConsumer::Event::Type::Exec) {
-    row["type"] = action;
+    row["type"] = std::move(action);
 
     if (event.opt_exec_event_data.has_value()) {
       const auto &exec_event_data = event.opt_exec_event_data.value();
@@ -176,7 +177,7 @@ Status ProcessEventsTablePlugin::generateRow(
     }
 
   } else if (event.type == IEndpointSecurityConsumer::Event::Type::Fork) {
-    row["type"] = action;
+    row["type"] = std::move(action);
 
     if (event.opt_exec_event_data.has_value()) {
       return Status::failure("Invalid event data");

--- a/tables/endpointsecurity/src/processeventstableplugin.cpp
+++ b/tables/endpointsecurity/src/processeventstableplugin.cpp
@@ -93,16 +93,18 @@ Status ProcessEventsTablePlugin::processEvents(
   }
 
   if (d->row_list.size() > d->max_queued_row_count) {
-    auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
 
-    d->logger.logMessage(IZeekLogger::Severity::Warning,
-                         "process_events: Dropping " +
-                             std::to_string(rows_to_remove) +
-                             " rows (max row count is set to " +
-                             std::to_string(d->max_queued_row_count) + ")");
+    std::lock_guard<std::mutex> lock(d->row_list_mutex);
 
-    {
-      std::lock_guard<std::mutex> lock(d->row_list_mutex);
+    if (d->row_list.size() > d->max_queued_row_count) {
+      auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
+
+      d->logger.logMessage(IZeekLogger::Severity::Warning,
+                           "process_events: Dropping " +
+                               std::to_string(rows_to_remove) +
+                               " rows (max row count is set to " +
+                               std::to_string(d->max_queued_row_count) + ")");
+
       d->row_list.erase(d->row_list.begin(),
                         std::next(d->row_list.begin(), rows_to_remove));
     }

--- a/tables/endpointsecurity/src/processeventstableplugin.cpp
+++ b/tables/endpointsecurity/src/processeventstableplugin.cpp
@@ -45,23 +45,21 @@ const std::string &ProcessEventsTablePlugin::name() const {
 
 const ProcessEventsTablePlugin::Schema &
 ProcessEventsTablePlugin::schema() const {
-  // clang-format off
+
   static const Schema kTableSchema = {
-    { "timestamp", IVirtualTable::ColumnType::Integer },
-    { "type", IVirtualTable::ColumnType::String },
-    { "parent_process_id", IVirtualTable::ColumnType::Integer },
-    { "orig_parent_process_id", IVirtualTable::ColumnType::Integer },
-    { "process_id", IVirtualTable::ColumnType::Integer },
-    { "user_id", IVirtualTable::ColumnType::Integer },
-    { "group_id", IVirtualTable::ColumnType::Integer },
-    { "platform_binary", IVirtualTable::ColumnType::Integer },
-    { "signing_id", IVirtualTable::ColumnType::String },
-    { "team_id", IVirtualTable::ColumnType::String },
-    { "cdhash", IVirtualTable::ColumnType::String },
-    { "path", IVirtualTable::ColumnType::String },
-    { "cmdline", IVirtualTable::ColumnType::String }
-  };
-  // clang-format on
+      {"timestamp", IVirtualTable::ColumnType::Integer},
+      {"type", IVirtualTable::ColumnType::String},
+      {"parent_process_id", IVirtualTable::ColumnType::Integer},
+      {"orig_parent_process_id", IVirtualTable::ColumnType::Integer},
+      {"process_id", IVirtualTable::ColumnType::Integer},
+      {"user_id", IVirtualTable::ColumnType::Integer},
+      {"group_id", IVirtualTable::ColumnType::Integer},
+      {"platform_binary", IVirtualTable::ColumnType::Integer},
+      {"signing_id", IVirtualTable::ColumnType::String},
+      {"team_id", IVirtualTable::ColumnType::String},
+      {"cdhash", IVirtualTable::ColumnType::String},
+      {"path", IVirtualTable::ColumnType::String},
+      {"cmdline", IVirtualTable::ColumnType::String}};
 
   return kTableSchema;
 }
@@ -95,13 +93,9 @@ Status ProcessEventsTablePlugin::processEvents(
   {
     std::lock_guard<std::mutex> lock(d->row_list_mutex);
 
-    // clang-format off
-    d->row_list.insert(
-      d->row_list.end(),
-      std::make_move_iterator(generated_row_list.begin()),
-      std::make_move_iterator(generated_row_list.end())
-    );
-    // clang-format on
+    d->row_list.insert(d->row_list.end(),
+                       std::make_move_iterator(generated_row_list.begin()),
+                       std::make_move_iterator(generated_row_list.end()));
 
     if (d->row_list.size() > d->max_queued_row_count) {
       auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
@@ -112,12 +106,8 @@ Status ProcessEventsTablePlugin::processEvents(
                                " rows (max row count is set to " +
                                std::to_string(d->max_queued_row_count));
 
-      // clang-format off
-      d->row_list.erase(
-        d->row_list.begin(),
-        std::next(d->row_list.begin(), rows_to_remove)
-      );
-      // clang-format on
+      d->row_list.erase(d->row_list.begin(),
+                        std::next(d->row_list.begin(), rows_to_remove));
     }
   }
 

--- a/tables/endpointsecurity/tests/fileeventstableplugin.cpp
+++ b/tables/endpointsecurity/tests/fileeventstableplugin.cpp
@@ -35,42 +35,41 @@ generateEvent(IEndpointSecurityConsumer::Event::Type type) {
 
 void validateRow(const IVirtualTable::Row &row,
                  const IEndpointSecurityConsumer::Event &event) {
-  REQUIRE(row.size() == 13U);
+  CHECK(row.size() == 13U);
 
-  REQUIRE(std::get<std::int64_t>(row.at("timestamp").value()) ==
-          event.header.timestamp);
+  CHECK(std::get<std::int64_t>(row.at("timestamp").value()) ==
+        event.header.timestamp);
 
-  REQUIRE(std::get<std::int64_t>(row.at("parent_process_id").value()) ==
-          event.header.parent_process_id);
+  CHECK(std::get<std::int64_t>(row.at("parent_process_id").value()) ==
+        event.header.parent_process_id);
 
-  REQUIRE(std::get<std::int64_t>(row.at("orig_parent_process_id").value()) ==
-          event.header.orig_parent_process_id);
+  CHECK(std::get<std::int64_t>(row.at("orig_parent_process_id").value()) ==
+        event.header.orig_parent_process_id);
 
-  REQUIRE(std::get<std::int64_t>(row.at("process_id").value()) ==
-          event.header.process_id);
+  CHECK(std::get<std::int64_t>(row.at("process_id").value()) ==
+        event.header.process_id);
 
-  REQUIRE(std::get<std::int64_t>(row.at("user_id").value()) ==
-          event.header.user_id);
+  CHECK(std::get<std::int64_t>(row.at("user_id").value()) ==
+        event.header.user_id);
 
-  REQUIRE(std::get<std::int64_t>(row.at("group_id").value()) ==
-          event.header.group_id);
+  CHECK(std::get<std::int64_t>(row.at("group_id").value()) ==
+        event.header.group_id);
 
-  REQUIRE(std::get<std::int64_t>(row.at("platform_binary").value()) ==
-          event.header.platform_binary);
+  CHECK(std::get<std::int64_t>(row.at("platform_binary").value()) ==
+        event.header.platform_binary);
 
-  REQUIRE(std::get<std::string>(row.at("signing_id").value()) ==
-          event.header.signing_id);
+  CHECK(std::get<std::string>(row.at("signing_id").value()) ==
+        event.header.signing_id);
 
-  REQUIRE(std::get<std::string>(row.at("team_id").value()) ==
-          event.header.team_id);
+  CHECK(std::get<std::string>(row.at("team_id").value()) ==
+        event.header.team_id);
 
-  REQUIRE(std::get<std::string>(row.at("cdhash").value()) ==
-          event.header.cdhash);
+  CHECK(std::get<std::string>(row.at("cdhash").value()) == event.header.cdhash);
 
-  REQUIRE(std::get<std::string>(row.at("path").value()) == event.header.path);
+  CHECK(std::get<std::string>(row.at("path").value()) == event.header.path);
 
-  REQUIRE(std::get<std::string>(row.at("file_path").value()) ==
-          event.header.file_path);
+  CHECK(std::get<std::string>(row.at("file_path").value()) ==
+        event.header.file_path);
 
   auto valid_event =
       event.type == IEndpointSecurityConsumer::Event::Type::Open ||
@@ -79,10 +78,10 @@ void validateRow(const IVirtualTable::Row &row,
   REQUIRE(valid_event);
 
   if (event.type == IEndpointSecurityConsumer::Event::Type::Open) {
-    REQUIRE(std::get<std::string>(row.at("type").value()) == "open");
+    CHECK(std::get<std::string>(row.at("type").value()) == "open");
 
   } else {
-    REQUIRE(std::get<std::string>(row.at("type").value()) == "create");
+    CHECK(std::get<std::string>(row.at("type").value()) == "create");
   }
 }
 } // namespace
@@ -95,7 +94,7 @@ SCENARIO("Row generation in the file_events table", "[FileEventsTablePlugin]") {
     WHEN("generating a table row") {
       IVirtualTable::Row row;
       auto status = FileEventsTablePlugin::generateRow(row, event);
-      REQUIRE(status.succeeded());
+      CHECK(status.succeeded());
 
       validateRow(row, event);
     }
@@ -107,7 +106,7 @@ SCENARIO("Row generation in the file_events table", "[FileEventsTablePlugin]") {
     WHEN("generating table rows") {
       IVirtualTable::Row row;
       auto status = FileEventsTablePlugin::generateRow(row, event);
-      REQUIRE(status.succeeded());
+      CHECK(status.succeeded());
 
       validateRow(row, event);
     }

--- a/tables/endpointsecurity/tests/fileeventstableplugin.cpp
+++ b/tables/endpointsecurity/tests/fileeventstableplugin.cpp
@@ -1,0 +1,116 @@
+#include "fileeventstableplugin.h"
+
+#include <catch2/catch.hpp>
+
+namespace zeek {
+namespace {
+IEndpointSecurityConsumer::Event
+generateEvent(IEndpointSecurityConsumer::Event::Type type) {
+  IEndpointSecurityConsumer::Event event;
+  event.header.timestamp = 1U;
+  event.header.parent_process_id = 2U;
+  event.header.orig_parent_process_id = 3U;
+  event.header.process_id = 4U;
+  event.header.user_id = 5U;
+  event.header.group_id = 6U;
+  event.header.platform_binary = true;
+  event.header.signing_id = "SigningID";
+  event.header.team_id = "TeamID";
+  event.header.cdhash = "12345";
+  event.header.path = "/path/to/application";
+  event.header.file_path = "/path/to/file";
+
+  if (type == IEndpointSecurityConsumer::Event::Type::Open) {
+    event.type = type;
+
+  } else if (type == IEndpointSecurityConsumer::Event::Type::Create) {
+    event.type = type;
+
+  } else {
+    throw std::logic_error("Invalid event type specified");
+  }
+
+  return event;
+}
+
+void validateRow(const IVirtualTable::Row &row,
+                 const IEndpointSecurityConsumer::Event &event) {
+  REQUIRE(row.size() == 13U);
+
+  REQUIRE(std::get<std::int64_t>(row.at("timestamp").value()) ==
+          event.header.timestamp);
+
+  REQUIRE(std::get<std::int64_t>(row.at("parent_process_id").value()) ==
+          event.header.parent_process_id);
+
+  REQUIRE(std::get<std::int64_t>(row.at("orig_parent_process_id").value()) ==
+          event.header.orig_parent_process_id);
+
+  REQUIRE(std::get<std::int64_t>(row.at("process_id").value()) ==
+          event.header.process_id);
+
+  REQUIRE(std::get<std::int64_t>(row.at("user_id").value()) ==
+          event.header.user_id);
+
+  REQUIRE(std::get<std::int64_t>(row.at("group_id").value()) ==
+          event.header.group_id);
+
+  REQUIRE(std::get<std::int64_t>(row.at("platform_binary").value()) ==
+          event.header.platform_binary);
+
+  REQUIRE(std::get<std::string>(row.at("signing_id").value()) ==
+          event.header.signing_id);
+
+  REQUIRE(std::get<std::string>(row.at("team_id").value()) ==
+          event.header.team_id);
+
+  REQUIRE(std::get<std::string>(row.at("cdhash").value()) ==
+          event.header.cdhash);
+
+  REQUIRE(std::get<std::string>(row.at("path").value()) == event.header.path);
+
+  REQUIRE(std::get<std::string>(row.at("file_path").value()) ==
+          event.header.file_path);
+
+  auto valid_event =
+      event.type == IEndpointSecurityConsumer::Event::Type::Open ||
+      event.type == IEndpointSecurityConsumer::Event::Type::Create;
+
+  REQUIRE(valid_event);
+
+  if (event.type == IEndpointSecurityConsumer::Event::Type::Open) {
+    REQUIRE(std::get<std::string>(row.at("type").value()) == "open");
+
+  } else {
+    REQUIRE(std::get<std::string>(row.at("type").value()) == "create");
+  }
+}
+} // namespace
+
+SCENARIO("Row generation in the file_events table", "[FileEventsTablePlugin]") {
+
+  GIVEN("a valid open EndpointSecurity event") {
+    auto event = generateEvent(IEndpointSecurityConsumer::Event::Type::Open);
+
+    WHEN("generating a table row") {
+      IVirtualTable::Row row;
+      auto status = FileEventsTablePlugin::generateRow(row, event);
+      REQUIRE(status.succeeded());
+
+      validateRow(row, event);
+    }
+  }
+
+  GIVEN("a valid create EndpointSecurity event") {
+    auto event = generateEvent(IEndpointSecurityConsumer::Event::Type::Create);
+
+    WHEN("generating table rows") {
+      IVirtualTable::Row row;
+      auto status = FileEventsTablePlugin::generateRow(row, event);
+      REQUIRE(status.succeeded());
+
+      validateRow(row, event);
+    }
+  }
+}
+} // namespace zeek

--- a/tables/endpointsecurity/tests/fileeventstableplugin.cpp
+++ b/tables/endpointsecurity/tests/fileeventstableplugin.cpp
@@ -35,6 +35,12 @@ generateEvent(IEndpointSecurityConsumer::Event::Type type) {
 
 void validateRow(const IVirtualTable::Row &row,
                  const IEndpointSecurityConsumer::Event &event) {
+  auto valid_event =
+      event.type == IEndpointSecurityConsumer::Event::Type::Open ||
+      event.type == IEndpointSecurityConsumer::Event::Type::Create;
+
+  REQUIRE(valid_event);
+
   CHECK(row.size() == 13U);
 
   CHECK(std::get<std::int64_t>(row.at("timestamp").value()) ==
@@ -71,12 +77,6 @@ void validateRow(const IVirtualTable::Row &row,
   CHECK(std::get<std::string>(row.at("file_path").value()) ==
         event.header.file_path);
 
-  auto valid_event =
-      event.type == IEndpointSecurityConsumer::Event::Type::Open ||
-      event.type == IEndpointSecurityConsumer::Event::Type::Create;
-
-  REQUIRE(valid_event);
-
   if (event.type == IEndpointSecurityConsumer::Event::Type::Open) {
     CHECK(std::get<std::string>(row.at("type").value()) == "open");
 
@@ -94,7 +94,7 @@ SCENARIO("Row generation in the file_events table", "[FileEventsTablePlugin]") {
     WHEN("generating a table row") {
       IVirtualTable::Row row;
       auto status = FileEventsTablePlugin::generateRow(row, event);
-      CHECK(status.succeeded());
+      REQUIRE(status.succeeded());
 
       validateRow(row, event);
     }
@@ -106,7 +106,7 @@ SCENARIO("Row generation in the file_events table", "[FileEventsTablePlugin]") {
     WHEN("generating table rows") {
       IVirtualTable::Row row;
       auto status = FileEventsTablePlugin::generateRow(row, event);
-      CHECK(status.succeeded());
+      REQUIRE(status.succeeded());
 
       validateRow(row, event);
     }

--- a/tables/endpointsecurity/tests/fileeventstableplugin.cpp
+++ b/tables/endpointsecurity/tests/fileeventstableplugin.cpp
@@ -27,7 +27,7 @@ generateEvent(IEndpointSecurityConsumer::Event::Type type) {
     event.type = type;
 
   } else {
-    throw std::logic_error("Invalid event type specified");
+    FAIL("Invalid event type specified");
   }
 
   return event;

--- a/tables/endpointsecurity/tests/processeventstableplugin.cpp
+++ b/tables/endpointsecurity/tests/processeventstableplugin.cpp
@@ -40,59 +40,58 @@ generateEvent(IEndpointSecurityConsumer::Event::Type type) {
 
 void validateRow(const IVirtualTable::Row &row,
                  const IEndpointSecurityConsumer::Event &event) {
-  REQUIRE(row.size() == 13U);
-
-  REQUIRE(std::get<std::int64_t>(row.at("timestamp").value()) ==
-          event.header.timestamp);
-
-  REQUIRE(std::get<std::int64_t>(row.at("parent_process_id").value()) ==
-          event.header.parent_process_id);
-
-  REQUIRE(std::get<std::int64_t>(row.at("orig_parent_process_id").value()) ==
-          event.header.orig_parent_process_id);
-
-  REQUIRE(std::get<std::int64_t>(row.at("process_id").value()) ==
-          event.header.process_id);
-
-  REQUIRE(std::get<std::int64_t>(row.at("user_id").value()) ==
-          event.header.user_id);
-
-  REQUIRE(std::get<std::int64_t>(row.at("group_id").value()) ==
-          event.header.group_id);
-
-  REQUIRE(std::get<std::int64_t>(row.at("platform_binary").value()) ==
-          event.header.platform_binary);
-
-  REQUIRE(std::get<std::string>(row.at("signing_id").value()) ==
-          event.header.signing_id);
-
-  REQUIRE(std::get<std::string>(row.at("team_id").value()) ==
-          event.header.team_id);
-
-  REQUIRE(std::get<std::string>(row.at("cdhash").value()) ==
-          event.header.cdhash);
-
-  REQUIRE(std::get<std::string>(row.at("path").value()) == event.header.path);
-
   auto valid_event =
       event.type == IEndpointSecurityConsumer::Event::Type::Exec ||
       event.type == IEndpointSecurityConsumer::Event::Type::Fork;
 
   REQUIRE(valid_event);
 
+  CHECK(row.size() == 13U);
+
+  CHECK(std::get<std::int64_t>(row.at("timestamp").value()) ==
+        event.header.timestamp);
+
+  CHECK(std::get<std::int64_t>(row.at("parent_process_id").value()) ==
+        event.header.parent_process_id);
+
+  CHECK(std::get<std::int64_t>(row.at("orig_parent_process_id").value()) ==
+        event.header.orig_parent_process_id);
+
+  CHECK(std::get<std::int64_t>(row.at("process_id").value()) ==
+        event.header.process_id);
+
+  CHECK(std::get<std::int64_t>(row.at("user_id").value()) ==
+        event.header.user_id);
+
+  CHECK(std::get<std::int64_t>(row.at("group_id").value()) ==
+        event.header.group_id);
+
+  CHECK(std::get<std::int64_t>(row.at("platform_binary").value()) ==
+        event.header.platform_binary);
+
+  CHECK(std::get<std::string>(row.at("signing_id").value()) ==
+        event.header.signing_id);
+
+  CHECK(std::get<std::string>(row.at("team_id").value()) ==
+        event.header.team_id);
+
+  CHECK(std::get<std::string>(row.at("cdhash").value()) == event.header.cdhash);
+
+  CHECK(std::get<std::string>(row.at("path").value()) == event.header.path);
+
   if (event.type == IEndpointSecurityConsumer::Event::Type::Exec) {
-    REQUIRE(std::get<std::string>(row.at("type").value()) == "exec");
+    CHECK(std::get<std::string>(row.at("type").value()) == "exec");
 
     std::string expected_cmd_line;
     for (const auto &arg : event.opt_exec_event_data.value().argument_list) {
       expected_cmd_line += " " + arg;
     }
 
-    REQUIRE(std::get<std::string>(row.at("cmdline").value()) ==
-            expected_cmd_line);
+    CHECK(std::get<std::string>(row.at("cmdline").value()) ==
+          expected_cmd_line);
 
   } else {
-    REQUIRE(std::get<std::string>(row.at("type").value()) == "fork");
+    CHECK(std::get<std::string>(row.at("type").value()) == "fork");
   }
 }
 } // namespace


### PR DESCRIPTION
This PR adds file events table `FileEventsTablePlugin` to macOS. Currently, it handles  `Open` and `Create` file event types. I have also included tests for this table.
Later, I will submit a PR to `zeek-agent-framework` repo with an example Zeek script to fetch events from this table. 