### PR TITLE
Adding file events table to Linux platform and standardize variable/column names across tables

### DIFF
--- a/components/zeekaudisp/include/zeek/iaudispconsumer.h
+++ b/components/zeekaudisp/include/zeek/iaudispconsumer.h
@@ -13,7 +13,18 @@ public:
   /// \brief SYSCALL record data
   struct SyscallRecordData final {
     /// \brief Supported syscalls
-    enum class Type { Execve, ExecveAt, Fork, VFork, Clone, Bind, Connect };
+    enum class Type {
+      Execve,
+      ExecveAt,
+      Fork,
+      VFork,
+      Clone,
+      Bind,
+      Connect,
+      Open,
+      OpenAt,
+      Create
+    };
 
     /// \brief Event type
     Type type;
@@ -83,6 +94,9 @@ public:
 
     /// \brief Owner group id
     std::int64_t ogid{0};
+
+    /// \brief File Inode
+    std::int64_t inode{0};
   };
 
   /// \brief A list of PATH records

--- a/tables/audisp/CMakeLists.txt
+++ b/tables/audisp/CMakeLists.txt
@@ -8,6 +8,9 @@ function(zeekAgentTablesAudisp)
     src/socketeventstableplugin.h
     src/socketeventstableplugin.cpp
 
+    src/fileeventstableplugin.h
+    src/fileeventstableplugin.cpp
+
     src/processeventstableplugin.h
     src/processeventstableplugin.cpp
 
@@ -44,6 +47,7 @@ function(zeekAgentTablesAudisp)
 
       tests/processeventstableplugin.cpp
       tests/socketeventstableplugin.cpp
+      tests/fileeventstableplugin.cpp
   )
 endfunction()
 

--- a/tables/audisp/src/fileeventstableplugin.cpp
+++ b/tables/audisp/src/fileeventstableplugin.cpp
@@ -1,0 +1,240 @@
+#include "fileeventstableplugin.h"
+
+#include <chrono>
+#include <filesystem>
+#include <mutex>
+
+namespace zeek {
+struct FileEventsTablePlugin::PrivateData final {
+  PrivateData(IZeekConfiguration &configuration_, IZeekLogger &logger_)
+      : configuration(configuration_), logger(logger_) {}
+
+  IZeekConfiguration &configuration;
+  IZeekLogger &logger;
+
+  RowList row_list;
+  std::mutex row_list_mutex;
+  std::size_t max_queued_row_count{0U};
+};
+
+Status FileEventsTablePlugin::create(Ref &obj,
+                                     IZeekConfiguration &configuration,
+                                     IZeekLogger &logger) {
+  try {
+    auto ptr = new FileEventsTablePlugin(configuration, logger);
+    obj.reset(ptr);
+
+    return Status::success();
+
+  } catch (const std::bad_alloc &) {
+    return Status::failure("Memory allocation failure");
+
+  } catch (const Status &status) {
+    return status;
+  }
+}
+
+FileEventsTablePlugin::~FileEventsTablePlugin() {}
+
+const std::string &FileEventsTablePlugin::name() const {
+  static const std::string kTableName{"file_events"};
+
+  return kTableName;
+}
+
+const FileEventsTablePlugin::Schema &FileEventsTablePlugin::schema() const {
+  static const Schema kTableSchema = {
+      {"syscall", IVirtualTable::ColumnType::String},
+      {"pid", IVirtualTable::ColumnType::Integer},
+      {"ppid", IVirtualTable::ColumnType::Integer},
+      {"uid", IVirtualTable::ColumnType::Integer},
+      {"gid", IVirtualTable::ColumnType::Integer},
+      {"auid", IVirtualTable::ColumnType::Integer},
+      {"euid", IVirtualTable::ColumnType::Integer},
+      {"egid", IVirtualTable::ColumnType::Integer},
+      {"exe", IVirtualTable::ColumnType::String},
+      {"path", IVirtualTable::ColumnType::String},
+      {"inode", IVirtualTable::ColumnType::Integer},
+      {"time", IVirtualTable::ColumnType::Integer}};
+
+  return kTableSchema;
+}
+
+Status FileEventsTablePlugin::generateRowList(RowList &row_list) {
+  std::lock_guard<std::mutex> lock(d->row_list_mutex);
+
+  row_list = std::move(d->row_list);
+  d->row_list = {};
+
+  return Status::success();
+}
+
+Status FileEventsTablePlugin::processEvents(
+    const IAudispConsumer::AuditEventList &event_list) {
+  RowList generated_row_list;
+
+  for (const auto &audit_event : event_list) {
+    Row row;
+
+    auto status = generateRow(row, audit_event);
+    if (!status.succeeded()) {
+      return status;
+    }
+
+    if (!row.empty()) {
+      {
+        std::lock_guard<std::mutex> lock(d->row_list_mutex);
+        d->row_list.push_back(row);
+      }
+    }
+  }
+
+  if (d->row_list.size() > d->max_queued_row_count) {
+
+    auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
+
+    d->logger.logMessage(IZeekLogger::Severity::Warning,
+                         "file_events: Dropping " +
+                             std::to_string(rows_to_remove) +
+                             " rows (max row count is set to " +
+                             std::to_string(d->max_queued_row_count) + ")");
+
+    {
+      std::lock_guard<std::mutex> lock(d->row_list_mutex);
+      d->row_list.erase(d->row_list.begin(),
+                        std::next(d->row_list.begin(), rows_to_remove));
+    }
+  }
+
+  return Status::success();
+}
+
+FileEventsTablePlugin::FileEventsTablePlugin(IZeekConfiguration &configuration,
+                                             IZeekLogger &logger)
+    : d(new PrivateData(configuration, logger)) {
+
+  d->max_queued_row_count = d->configuration.maxQueuedRowCount();
+}
+
+std::string FileEventsTablePlugin::CombinePaths(const std::string &cwd,
+                                                const std::string &path) {
+  std::string full_path;
+
+  // Quotes are only present when path contain space
+  if (path[0] == '"') {
+    full_path = path.substr(1, path.size() - 2);
+  } else {
+    full_path = path;
+  }
+
+  // Use cwd when path is not absolute
+  if (full_path[0] != '/') {
+    std::string normalized_cwd;
+
+    if (cwd[0] == '"') {
+      normalized_cwd = cwd.substr(1, cwd.size() - 2);
+    } else {
+      normalized_cwd = cwd;
+    }
+
+    full_path = std::filesystem::path(normalized_cwd) / full_path;
+  }
+  return full_path;
+}
+
+Status FileEventsTablePlugin::generateRow(
+    Row &row, const IAudispConsumer::AuditEvent &audit_event) {
+  row = {};
+
+  std::string syscall;
+  std::string full_path;
+  std::int64_t inode;
+  switch (audit_event.syscall_data.type) {
+  case IAudispConsumer::SyscallRecordData::Type::Open:
+  case IAudispConsumer::SyscallRecordData::Type::OpenAt: {
+    if (!audit_event.cwd_data.has_value()) {
+      return Status::failure("Missing an AUDIT_CWD record from a file event");
+    }
+    if (!audit_event.path_data.has_value()) {
+      return Status::failure("Missing an AUDIT_PATH record from a file event");
+    }
+    if (audit_event.syscall_data.type ==
+        IAudispConsumer::SyscallRecordData::Type::Open)
+      syscall = "open";
+    else
+      syscall = "openat";
+
+    std::string working_dir_path;
+    std::string file_path;
+    const auto &path_record = audit_event.path_data.value();
+    const auto &cwd_record = audit_event.cwd_data.value();
+
+    if (path_record.size() == 1) {
+      working_dir_path = cwd_record;
+      file_path = path_record.at(0).path;
+      inode = path_record.at(0).inode;
+
+    } else if (path_record.size() == 2) {
+      working_dir_path = path_record.at(0).path;
+      file_path = path_record.at(1).path;
+      inode = path_record.at(1).inode;
+
+    } else if (path_record.size() == 3) {
+      working_dir_path = cwd_record;
+      file_path = path_record.at(0).path;
+      inode = path_record.at(0).inode;
+
+    } else {
+      return Status::failure(
+          "Wrong number of path records for open/openat syscall event");
+    }
+    full_path = CombinePaths(working_dir_path, file_path);
+    break;
+  }
+  case IAudispConsumer::SyscallRecordData::Type::Create: {
+    if (!audit_event.path_data.has_value()) {
+      return Status::failure("Missing an AUDIT_PATH record from a file event");
+    }
+    syscall = "create";
+    const auto &path_record = audit_event.path_data.value();
+    if (path_record.size() != 2) {
+      return Status::failure(
+          "Wrong number of path records for create syscall event");
+    }
+    std::string working_dir_path = path_record.at(0).path;
+    std::string file_path = path_record.at(1).path;
+    full_path = CombinePaths(working_dir_path, file_path);
+    inode = path_record.at(1).inode;
+    break;
+  }
+  case IAudispConsumer::SyscallRecordData::Type::Execve:
+  case IAudispConsumer::SyscallRecordData::Type::ExecveAt:
+  case IAudispConsumer::SyscallRecordData::Type::Fork:
+  case IAudispConsumer::SyscallRecordData::Type::VFork:
+  case IAudispConsumer::SyscallRecordData::Type::Clone:
+  case IAudispConsumer::SyscallRecordData::Type::Bind:
+  case IAudispConsumer::SyscallRecordData::Type::Connect:
+    return Status::success();
+  }
+
+  const auto &syscall_data = audit_event.syscall_data;
+
+  row["syscall"] = std::move(syscall);
+  row["pid"] = syscall_data.process_id;
+  row["ppid"] = syscall_data.parent_process_id;
+  row["uid"] = syscall_data.uid;
+  row["gid"] = syscall_data.gid;
+  row["auid"] = syscall_data.auid;
+  row["euid"] = syscall_data.euid;
+  row["egid"] = syscall_data.egid;
+  row["exe"] = syscall_data.exe;
+  row["path"] = std::move(full_path);
+  row["inode"] = inode;
+  auto current_timestamp = std::chrono::duration_cast<std::chrono::seconds>(
+      std::chrono::system_clock::now().time_since_epoch());
+
+  row["time"] = static_cast<std::int64_t>(current_timestamp.count());
+
+  return Status::success();
+}
+} // namespace zeek

--- a/tables/audisp/src/fileeventstableplugin.cpp
+++ b/tables/audisp/src/fileeventstableplugin.cpp
@@ -147,7 +147,7 @@ Status FileEventsTablePlugin::generateRow(
     Row &row, const IAudispConsumer::AuditEvent &audit_event) {
   row = {};
 
-  std::string syscall;
+  std::string syscall_name;
   std::string full_path;
   std::int64_t inode;
   switch (audit_event.syscall_data.type) {
@@ -161,9 +161,9 @@ Status FileEventsTablePlugin::generateRow(
     }
     if (audit_event.syscall_data.type ==
         IAudispConsumer::SyscallRecordData::Type::Open)
-      syscall = "open";
+      syscall_name = "open";
     else
-      syscall = "openat";
+      syscall_name = "openat";
 
     std::string working_dir_path;
     std::string file_path;
@@ -196,7 +196,7 @@ Status FileEventsTablePlugin::generateRow(
     if (!audit_event.path_data.has_value()) {
       return Status::failure("Missing an AUDIT_PATH record from a file event");
     }
-    syscall = "create";
+    syscall_name = "create";
     const auto &path_record = audit_event.path_data.value();
     if (path_record.size() != 2) {
       return Status::failure(
@@ -220,7 +220,7 @@ Status FileEventsTablePlugin::generateRow(
 
   const auto &syscall_data = audit_event.syscall_data;
 
-  row["syscall"] = std::move(syscall);
+  row["syscall"] = std::move(syscall_name);
   row["pid"] = syscall_data.process_id;
   row["ppid"] = syscall_data.parent_process_id;
   row["uid"] = syscall_data.uid;

--- a/tables/audisp/src/fileeventstableplugin.h
+++ b/tables/audisp/src/fileeventstableplugin.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <zeek/iaudispconsumer.h>
+#include <zeek/ivirtualtable.h>
+#include <zeek/izeekconfiguration.h>
+#include <zeek/izeeklogger.h>
+
+namespace zeek {
+/// \brief Provides the file_events table
+class FileEventsTablePlugin final : public IVirtualTable {
+  struct PrivateData;
+  std::unique_ptr<PrivateData> d;
+
+public:
+  /// \brief Factory method
+  /// \param obj Where the created object is stored
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  /// \return A Status object
+  static Status create(Ref &obj, IZeekConfiguration &configuration,
+                       IZeekLogger &logger);
+
+  /// \brief Destructor
+  virtual ~FileEventsTablePlugin() override;
+
+  /// \return The table name
+  virtual const std::string &name() const override;
+
+  /// \return The table schema
+  virtual const Schema &schema() const override;
+
+  /// \brief Generates the row list containing the fields from the given
+  ///        configuration object
+  /// \param row_list Where the generated rows are stored
+  /// \return A Status object
+  virtual Status generateRowList(RowList &row_list) override;
+
+  /// \brief Processes the specified event list, generating new rows
+  /// \param event_list A list of Audit events
+  /// \return A Status object
+  Status processEvents(const IAudispConsumer::AuditEventList &event_list);
+
+protected:
+  /// \brief Constructor
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  FileEventsTablePlugin(IZeekConfiguration &configuration, IZeekLogger &logger);
+
+  /// \brief Combines working directory with file path
+  /// \param cwd current directory path
+  /// \param path file path
+  static std::string CombinePaths(const std::string &cwd,
+                                  const std::string &path);
+
+public:
+  /// \brief Generates a single row from the given Audit event
+  /// \param audit_event a single Audit event
+  /// \return A Status object
+  static Status generateRow(Row &row,
+                            const IAudispConsumer::AuditEvent &audit_event);
+};
+} // namespace zeek

--- a/tables/audisp/src/fileeventstableplugin.h
+++ b/tables/audisp/src/fileeventstableplugin.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <memory>
+#include <string>
 #include <zeek/iaudispconsumer.h>
 #include <zeek/ivirtualtable.h>
 #include <zeek/izeekconfiguration.h>
 #include <zeek/izeeklogger.h>
+#include <zeek/status.h>
 
 namespace zeek {
 /// \brief Provides the file_events table

--- a/tables/audisp/src/fileeventstableplugin.h
+++ b/tables/audisp/src/fileeventstableplugin.h
@@ -40,6 +40,13 @@ public:
   /// \return A Status object
   Status processEvents(const IAudispConsumer::AuditEventList &event_list);
 
+  /// \brief Generates a single row from the given Audit event
+  /// \param row Where the generated row is stored
+  /// \param audit_event a single Audit event
+  /// \return A Status object
+  static Status generateRow(Row &row,
+                            const IAudispConsumer::AuditEvent &audit_event);
+
 protected:
   /// \brief Constructor
   /// \param configuration An initialized configuration object
@@ -51,12 +58,5 @@ protected:
   /// \param path file path
   static std::string CombinePaths(const std::string &cwd,
                                   const std::string &path);
-
-public:
-  /// \brief Generates a single row from the given Audit event
-  /// \param audit_event a single Audit event
-  /// \return A Status object
-  static Status generateRow(Row &row,
-                            const IAudispConsumer::AuditEvent &audit_event);
 };
 } // namespace zeek

--- a/tables/audisp/src/processeventstableplugin.cpp
+++ b/tables/audisp/src/processeventstableplugin.cpp
@@ -142,27 +142,27 @@ Status ProcessEventsTablePlugin::generateRow(
   }
 
   const auto &syscall_data = audit_event.syscall_data;
-  std::string syscall;
+  std::string syscall_name;
 
   switch (syscall_data.type) {
   case IAudispConsumer::SyscallRecordData::Type::Execve:
-    syscall = "execve";
+    syscall_name = "execve";
     break;
 
   case IAudispConsumer::SyscallRecordData::Type::ExecveAt:
-    syscall = "execveat";
+    syscall_name = "execveat";
     break;
 
   case IAudispConsumer::SyscallRecordData::Type::Fork:
-    syscall = "fork";
+    syscall_name = "fork";
     break;
 
   case IAudispConsumer::SyscallRecordData::Type::VFork:
-    syscall = "vfork";
+    syscall_name = "vfork";
     break;
 
   case IAudispConsumer::SyscallRecordData::Type::Clone:
-    syscall = "clone";
+    syscall_name = "clone";
     break;
   case IAudispConsumer::SyscallRecordData::Type::Bind:
   case IAudispConsumer::SyscallRecordData::Type::Connect:
@@ -178,7 +178,7 @@ Status ProcessEventsTablePlugin::generateRow(
   auto time_value = static_cast<std::int64_t>(current_timestamp.count());
 
   row["time"] = time_value;
-  row["syscall"] = syscall;
+  row["syscall"] = std::move(syscall_name);
   row["pid"] = syscall_data.process_id;
   row["ppid"] = syscall_data.parent_process_id;
   row["auid"] = syscall_data.auid;

--- a/tables/audisp/src/processeventstableplugin.cpp
+++ b/tables/audisp/src/processeventstableplugin.cpp
@@ -19,7 +19,6 @@ struct ProcessEventsTablePlugin::PrivateData final {
 Status ProcessEventsTablePlugin::create(Ref &obj,
                                         IZeekConfiguration &configuration,
                                         IZeekLogger &logger) {
-  obj.reset();
 
   try {
     auto ptr = new ProcessEventsTablePlugin(configuration, logger);
@@ -45,35 +44,34 @@ const std::string &ProcessEventsTablePlugin::name() const {
 
 const ProcessEventsTablePlugin::Schema &
 ProcessEventsTablePlugin::schema() const {
-  // clang-format off
   static const Schema kTableSchema = {
-    // Present in the AUDIT_SYSCALL record
-    { "syscall", IVirtualTable::ColumnType::String },
-    { "pid", IVirtualTable::ColumnType::Integer },
-    { "parent", IVirtualTable::ColumnType::Integer },
-    { "auid", IVirtualTable::ColumnType::Integer },
-    { "uid", IVirtualTable::ColumnType::Integer },
-    { "euid", IVirtualTable::ColumnType::Integer },
-    { "gid", IVirtualTable::ColumnType::Integer },
-    { "egid", IVirtualTable::ColumnType::Integer },
-    { "owner_uid", IVirtualTable::ColumnType::Integer },
-    { "owner_gid", IVirtualTable::ColumnType::Integer },
+      // Present in the AUDIT_SYSCALL record
+      {"syscall", IVirtualTable::ColumnType::String},
+      {"pid", IVirtualTable::ColumnType::Integer},
+      {"ppid", IVirtualTable::ColumnType::Integer},
+      {"auid", IVirtualTable::ColumnType::Integer},
+      {"uid", IVirtualTable::ColumnType::Integer},
+      {"euid", IVirtualTable::ColumnType::Integer},
+      {"gid", IVirtualTable::ColumnType::Integer},
+      {"egid", IVirtualTable::ColumnType::Integer},
+      {"exe", IVirtualTable::ColumnType::String},
+      {"exit", IVirtualTable::ColumnType::Integer},
 
-    // Present in the AUDIT_EXECVE record(s)
-    { "cmdline_size", IVirtualTable::ColumnType::Integer },
-    { "cmdline", IVirtualTable::ColumnType::String },
+      // Present in the AUDIT_EXECVE record(s)
+      {"cmdline", IVirtualTable::ColumnType::String},
 
-    // Present in the AUDIT_PATH record(s)
-    { "path", IVirtualTable::ColumnType::String },
-    { "mode", IVirtualTable::ColumnType::String },
-    
-    // Present in the AUDIT_CWD record
-    { "cwd", IVirtualTable::ColumnType::String },
-    
-    // Custom
-    { "time", IVirtualTable::ColumnType::Integer }
-  };
-  // clang-format on
+      // Present in the AUDIT_PATH record(s)
+      {"path", IVirtualTable::ColumnType::String},
+      {"mode", IVirtualTable::ColumnType::Integer},
+      {"inode", IVirtualTable::ColumnType::Integer},
+      {"ouid", IVirtualTable::ColumnType::Integer},
+      {"ogid", IVirtualTable::ColumnType::Integer},
+
+      // Present in the AUDIT_CWD record
+      {"cwd", IVirtualTable::ColumnType::String},
+
+      // Custom
+      {"time", IVirtualTable::ColumnType::Integer}};
 
   return kTableSchema;
 }
@@ -100,36 +98,27 @@ Status ProcessEventsTablePlugin::processEvents(
     }
 
     if (!row.empty()) {
-      generated_row_list.push_back(std::move(row));
+      {
+        std::lock_guard<std::mutex> lock(d->row_list_mutex);
+        d->row_list.push_back(row);
+      }
     }
   }
 
-  {
-    std::lock_guard<std::mutex> lock(d->row_list_mutex);
+  if (d->row_list.size() > d->max_queued_row_count) {
 
-    // clang-format off
-    d->row_list.insert(
-      d->row_list.end(),
-      std::make_move_iterator(generated_row_list.begin()), 
-      std::make_move_iterator(generated_row_list.end())
-    );
-    // clang-format on
+    auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
 
-    if (d->row_list.size() > d->max_queued_row_count) {
-      auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
+    d->logger.logMessage(IZeekLogger::Severity::Warning,
+                         "process_events: Dropping " +
+                             std::to_string(rows_to_remove) +
+                             " rows (max row count is set to " +
+                             std::to_string(d->max_queued_row_count) + ")");
 
-      d->logger.logMessage(IZeekLogger::Severity::Warning,
-                           "process_events: Dropping " +
-                               std::to_string(rows_to_remove) +
-                               " rows (max row count is set to " +
-                               std::to_string(d->max_queued_row_count));
-
-      // clang-format off
-      d->row_list.erase(
-        d->row_list.begin(),
-        std::next(d->row_list.begin(), rows_to_remove)
-      );
-      // clang-format on
+    {
+      std::lock_guard<std::mutex> lock(d->row_list_mutex);
+      d->row_list.erase(d->row_list.begin(),
+                        std::next(d->row_list.begin(), rows_to_remove));
     }
   }
 
@@ -152,30 +141,33 @@ Status ProcessEventsTablePlugin::generateRow(
   }
 
   const auto &syscall_data = audit_event.syscall_data;
-  const char *syscall_name{nullptr};
+  std::string syscall;
 
   switch (syscall_data.type) {
   case IAudispConsumer::SyscallRecordData::Type::Execve:
-    syscall_name = "execve";
+    syscall = "execve";
     break;
 
   case IAudispConsumer::SyscallRecordData::Type::ExecveAt:
-    syscall_name = "execveat";
+    syscall = "execveat";
     break;
 
   case IAudispConsumer::SyscallRecordData::Type::Fork:
-    syscall_name = "fork";
+    syscall = "fork";
     break;
 
   case IAudispConsumer::SyscallRecordData::Type::VFork:
-    syscall_name = "vfork";
+    syscall = "vfork";
     break;
 
   case IAudispConsumer::SyscallRecordData::Type::Clone:
-    syscall_name = "clone";
+    syscall = "clone";
     break;
-
-  default:
+  case IAudispConsumer::SyscallRecordData::Type::Bind:
+  case IAudispConsumer::SyscallRecordData::Type::Connect:
+  case IAudispConsumer::SyscallRecordData::Type::Open:
+  case IAudispConsumer::SyscallRecordData::Type::OpenAt:
+  case IAudispConsumer::SyscallRecordData::Type::Create:
     return Status::success();
   }
 
@@ -185,15 +177,16 @@ Status ProcessEventsTablePlugin::generateRow(
   auto time_value = static_cast<std::int64_t>(current_timestamp.count());
 
   row["time"] = time_value;
-  row["syscall"] = syscall_name;
+  row["syscall"] = syscall;
   row["pid"] = syscall_data.process_id;
-  row["parent"] = syscall_data.parent_process_id;
-  row["pid"] = syscall_data.process_id;
+  row["ppid"] = syscall_data.parent_process_id;
   row["auid"] = syscall_data.auid;
   row["uid"] = syscall_data.uid;
   row["euid"] = syscall_data.euid;
   row["gid"] = syscall_data.gid;
   row["egid"] = syscall_data.egid;
+  row["exe"] = syscall_data.exe;
+  row["exit"] = syscall_data.exit_code;
 
   if (syscall_data.type == IAudispConsumer::SyscallRecordData::Type::Execve ||
       syscall_data.type == IAudispConsumer::SyscallRecordData::Type::ExecveAt) {
@@ -224,15 +217,15 @@ Status ProcessEventsTablePlugin::generateRow(
     }
 
     row["cmdline"] = command_line;
-    row["cmdline_size"] = static_cast<std::int64_t>(command_line.size());
 
     const auto &path_record = audit_event.path_data.value();
     const auto &last_path_entry = path_record.front();
 
     row["path"] = last_path_entry.path;
     row["mode"] = last_path_entry.mode;
-    row["owner_uid"] = last_path_entry.ouid;
-    row["owner_gid"] = last_path_entry.ogid;
+    row["inode"] = last_path_entry.inode;
+    row["ouid"] = last_path_entry.ouid;
+    row["ogid"] = last_path_entry.ogid;
 
     const auto &cwd_data = audit_event.cwd_data.value();
 
@@ -247,12 +240,12 @@ Status ProcessEventsTablePlugin::generateRow(
     // we'll just set these values to either zero or an empty string
     std::int64_t null_value{0};
 
-    row["owner_uid"] = {null_value};
-    row["owner_gid"] = {null_value};
     row["cmdline"] = {""};
-    row["cmdline_size"] = {null_value};
     row["path"] = {""};
     row["mode"] = {null_value};
+    row["inode"] = {null_value};
+    row["ouid"] = {null_value};
+    row["ogid"] = {null_value};
     row["cwd"] = {""};
   }
 

--- a/tables/audisp/src/processeventstableplugin.cpp
+++ b/tables/audisp/src/processeventstableplugin.cpp
@@ -107,16 +107,17 @@ Status ProcessEventsTablePlugin::processEvents(
 
   if (d->row_list.size() > d->max_queued_row_count) {
 
-    auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
+    std::lock_guard<std::mutex> lock(d->row_list_mutex);
 
-    d->logger.logMessage(IZeekLogger::Severity::Warning,
-                         "process_events: Dropping " +
-                             std::to_string(rows_to_remove) +
-                             " rows (max row count is set to " +
-                             std::to_string(d->max_queued_row_count) + ")");
+    if (d->row_list.size() > d->max_queued_row_count) {
+      auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
 
-    {
-      std::lock_guard<std::mutex> lock(d->row_list_mutex);
+      d->logger.logMessage(IZeekLogger::Severity::Warning,
+                           "process_events: Dropping " +
+                               std::to_string(rows_to_remove) +
+                               " rows (max row count is set to " +
+                               std::to_string(d->max_queued_row_count) + ")");
+
       d->row_list.erase(d->row_list.begin(),
                         std::next(d->row_list.begin(), rows_to_remove));
     }

--- a/tables/audisp/src/processeventstableplugin.h
+++ b/tables/audisp/src/processeventstableplugin.h
@@ -40,18 +40,18 @@ public:
   /// \return A Status object
   Status processEvents(const IAudispConsumer::AuditEventList &event_list);
 
+  /// \brief Generates a single row from the given Audit event
+  /// \param row Where the generated row is stored
+  /// \param audit_event a single Audit event
+  /// \return A Status object
+  static Status generateRow(Row &row,
+                            const IAudispConsumer::AuditEvent &audit_event);
+
 protected:
   /// \brief Constructor
   /// \param configuration An initialized configuration object
   /// \param logger An initialized logger object
   ProcessEventsTablePlugin(IZeekConfiguration &configuration,
                            IZeekLogger &logger);
-
-public:
-  /// \brief Generates a single row from the given Audit event
-  /// \param audit_event a single Audit event
-  /// \return A Status object
-  static Status generateRow(Row &row,
-                            const IAudispConsumer::AuditEvent &audit_event);
 };
 } // namespace zeek

--- a/tables/audisp/src/socketeventstableplugin.cpp
+++ b/tables/audisp/src/socketeventstableplugin.cpp
@@ -19,8 +19,6 @@ struct SocketEventsTablePlugin::PrivateData final {
 Status SocketEventsTablePlugin::create(Ref &obj,
                                        IZeekConfiguration &configuration,
                                        IZeekLogger &logger) {
-  obj.reset();
-
   try {
     auto ptr = new SocketEventsTablePlugin(configuration, logger);
     obj.reset(ptr);
@@ -44,22 +42,25 @@ const std::string &SocketEventsTablePlugin::name() const {
 }
 
 const SocketEventsTablePlugin::Schema &SocketEventsTablePlugin::schema() const {
-  // clang-format off
+
   static const Schema kTableSchema = {
-    { "action", IVirtualTable::ColumnType::String },
-    { "pid", IVirtualTable::ColumnType::Integer },
-    { "path", IVirtualTable::ColumnType::String },
-    { "fd", IVirtualTable::ColumnType::String },
-    { "auid", IVirtualTable::ColumnType::Integer },
-    { "success", IVirtualTable::ColumnType::Integer },
-    { "family", IVirtualTable::ColumnType::Integer },
-    { "local_address", IVirtualTable::ColumnType::String },
-    { "remote_address", IVirtualTable::ColumnType::String },
-    { "local_port", IVirtualTable::ColumnType::Integer },
-    { "remote_port", IVirtualTable::ColumnType::Integer },
-    { "time", IVirtualTable::ColumnType::Integer }
-  };
-  // clang-format on
+      {"syscall", IVirtualTable::ColumnType::String},
+      {"pid", IVirtualTable::ColumnType::Integer},
+      {"ppid", IVirtualTable::ColumnType::Integer},
+      {"auid", IVirtualTable::ColumnType::Integer},
+      {"uid", IVirtualTable::ColumnType::Integer},
+      {"euid", IVirtualTable::ColumnType::Integer},
+      {"gid", IVirtualTable::ColumnType::Integer},
+      {"egid", IVirtualTable::ColumnType::Integer},
+      {"exe", IVirtualTable::ColumnType::String},
+      {"fd", IVirtualTable::ColumnType::String},
+      {"success", IVirtualTable::ColumnType::Integer},
+      {"family", IVirtualTable::ColumnType::Integer},
+      {"local_address", IVirtualTable::ColumnType::String},
+      {"remote_address", IVirtualTable::ColumnType::String},
+      {"local_port", IVirtualTable::ColumnType::Integer},
+      {"remote_port", IVirtualTable::ColumnType::Integer},
+      {"time", IVirtualTable::ColumnType::Integer}};
 
   return kTableSchema;
 }
@@ -86,36 +87,27 @@ Status SocketEventsTablePlugin::processEvents(
     }
 
     if (!row.empty()) {
-      generated_row_list.push_back(std::move(row));
+      {
+        std::lock_guard<std::mutex> lock(d->row_list_mutex);
+        d->row_list.push_back(row);
+      }
     }
   }
 
-  {
-    std::lock_guard<std::mutex> lock(d->row_list_mutex);
+  if (d->row_list.size() > d->max_queued_row_count) {
 
-    // clang-format off
-    d->row_list.insert(
-      d->row_list.end(),
-      std::make_move_iterator(generated_row_list.begin()), 
-      std::make_move_iterator(generated_row_list.end())
-    );
-    // clang-format on
+    auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
 
-    if (d->row_list.size() > d->max_queued_row_count) {
-      auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
+    d->logger.logMessage(IZeekLogger::Severity::Warning,
+                         "socket_events: Dropping " +
+                             std::to_string(rows_to_remove) +
+                             " rows (max row count is set to " +
+                             std::to_string(d->max_queued_row_count) + ")");
 
-      d->logger.logMessage(IZeekLogger::Severity::Warning,
-                           "socket_events: Dropping " +
-                               std::to_string(rows_to_remove) +
-                               " rows (max row count is set to " +
-                               std::to_string(d->max_queued_row_count));
-
-      // clang-format off
-      d->row_list.erase(
-        d->row_list.begin(),
-        std::next(d->row_list.begin(), rows_to_remove)
-      );
-      // clang-format on
+    {
+      std::lock_guard<std::mutex> lock(d->row_list_mutex);
+      d->row_list.erase(d->row_list.begin(),
+                        std::next(d->row_list.begin(), rows_to_remove));
     }
   }
 
@@ -133,15 +125,15 @@ Status SocketEventsTablePlugin::generateRow(
     Row &row, const IAudispConsumer::AuditEvent &audit_event) {
   row = {};
 
-  std::string action;
+  std::string syscall;
 
   switch (audit_event.syscall_data.type) {
   case IAudispConsumer::SyscallRecordData::Type::Bind:
-    action = "bind";
+    syscall = "bind";
     break;
 
   case IAudispConsumer::SyscallRecordData::Type::Connect:
-    action = "connect";
+    syscall = "connect";
     break;
 
   default:
@@ -155,14 +147,18 @@ Status SocketEventsTablePlugin::generateRow(
   const auto &syscall_data = audit_event.syscall_data;
   const auto &sockaddr_data = audit_event.sockaddr_data.value();
 
-  row["action"] = action;
+  row["syscall"] = syscall;
   row["pid"] = syscall_data.process_id;
-  row["path"] = syscall_data.exe;
+  row["ppid"] = syscall_data.parent_process_id;
+  row["auid"] = syscall_data.auid;
+  row["uid"] = syscall_data.uid;
+  row["euid"] = syscall_data.euid;
+  row["gid"] = syscall_data.gid;
+  row["egid"] = syscall_data.egid;
+  row["exe"] = syscall_data.exe;
 
   auto fd = std::strtoll(syscall_data.a0.c_str(), nullptr, 16U);
   row["fd"] = static_cast<std::int64_t>(fd);
-
-  row["auid"] = syscall_data.auid;
 
   row["success"] =
       static_cast<std::int64_t>(audit_event.syscall_data.succeeded ? 1 : 0);

--- a/tables/audisp/src/socketeventstableplugin.cpp
+++ b/tables/audisp/src/socketeventstableplugin.cpp
@@ -125,15 +125,15 @@ Status SocketEventsTablePlugin::generateRow(
     Row &row, const IAudispConsumer::AuditEvent &audit_event) {
   row = {};
 
-  std::string syscall;
+  std::string syscall_name;
 
   switch (audit_event.syscall_data.type) {
   case IAudispConsumer::SyscallRecordData::Type::Bind:
-    syscall = "bind";
+    syscall_name = "bind";
     break;
 
   case IAudispConsumer::SyscallRecordData::Type::Connect:
-    syscall = "connect";
+    syscall_name = "connect";
     break;
 
   default:
@@ -147,7 +147,7 @@ Status SocketEventsTablePlugin::generateRow(
   const auto &syscall_data = audit_event.syscall_data;
   const auto &sockaddr_data = audit_event.sockaddr_data.value();
 
-  row["syscall"] = syscall;
+  row["syscall"] = std::move(syscall_name);
   row["pid"] = syscall_data.process_id;
   row["ppid"] = syscall_data.parent_process_id;
   row["auid"] = syscall_data.auid;

--- a/tables/audisp/src/socketeventstableplugin.h
+++ b/tables/audisp/src/socketeventstableplugin.h
@@ -40,19 +40,18 @@ public:
   /// \return A Status object
   Status processEvents(const IAudispConsumer::AuditEventList &event_list);
 
-protected:
-  /// \brief Constructor
-  /// \param configuration An initialized configuration object
-  /// \param logger An initialized logger object
-  SocketEventsTablePlugin(IZeekConfiguration &configuration,
-                          IZeekLogger &logger);
-
-public:
   /// \brief Generates a new row from the given Audit event
   /// \param row Where the generated row is stored
   /// \param audit_event The source Audit event
   /// \return A Status object
   static Status generateRow(Row &row,
                             const IAudispConsumer::AuditEvent &audit_event);
+
+protected:
+  /// \brief Constructor
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  SocketEventsTablePlugin(IZeekConfiguration &configuration,
+                          IZeekLogger &logger);
 };
 } // namespace zeek

--- a/tables/audisp/tests/fileeventstableplugin.cpp
+++ b/tables/audisp/tests/fileeventstableplugin.cpp
@@ -1,0 +1,250 @@
+#include "fileeventstableplugin.h"
+#include "utils.h"
+
+#include <catch2/catch.hpp>
+
+namespace zeek {
+SCENARIO("Row generation in the file_events table", "[FileEventsTablePlugin]") {
+
+  GIVEN("a valid create syscall audit event") {
+
+    // clang-format off
+    static const IAudispConsumer::AuditEvent kCreateAuditEvent = {
+        // Syscall record data
+        {
+            IAudispConsumer::SyscallRecordData::Type::Create,
+            0,
+            38031,
+            38030,
+            true,
+            1000,
+            1000,
+            1000,
+            1000,
+            1000,
+            "/home/wajih/a.out",
+            "560a3d760004"
+        },
+
+        // Execve record data
+        {
+        },
+
+        // Path record data
+        {
+            {
+                {
+                    "/home/wajih",
+                    040755,
+                    1000,
+                    1000,
+                    668350
+                },
+
+                {
+                    "file.txt",
+                    0100744,
+                    1000,
+                    1000,
+                    677951
+                }
+            }
+        },
+
+        // Cwd data
+        {
+            "/home/wajih"
+        },
+
+        // Sockaddr data
+        {}
+    };
+    // clang-format on
+
+    WHEN("generating a table row") {
+      IVirtualTable::Row row;
+      auto status = FileEventsTablePlugin::generateRow(row, kCreateAuditEvent);
+
+      REQUIRE(status.succeeded());
+
+      THEN("rows are generated correctly") {
+        static ExpectedValueList kExpectedColumnList = {
+            {"syscall", "create"},
+            {"pid", kCreateAuditEvent.syscall_data.process_id},
+            {"ppid", kCreateAuditEvent.syscall_data.parent_process_id},
+            {"uid", kCreateAuditEvent.syscall_data.uid},
+            {"gid", kCreateAuditEvent.syscall_data.gid},
+            {"auid", kCreateAuditEvent.syscall_data.auid},
+            {"euid", kCreateAuditEvent.syscall_data.euid},
+            {"egid", kCreateAuditEvent.syscall_data.egid},
+            {"exe", "/home/wajih/a.out"},
+            {"path", "/home/wajih/file.txt"},
+            {"inode", static_cast<std::int64_t>(677951)}};
+
+        REQUIRE(row.size() == kExpectedColumnList.size() + 1);
+
+        REQUIRE(row.count("time") != 0U);
+        REQUIRE(row.at("time").has_value());
+
+        validateRow(row, kExpectedColumnList);
+      }
+    }
+  }
+  GIVEN("a valid open syscall audit event") {
+    // clang-format off
+    static const IAudispConsumer::AuditEvent kCreateAuditEvent = {
+        // Syscall record data
+        {
+            IAudispConsumer::SyscallRecordData::Type::Open,
+            0,
+            38031,
+            38030,
+            true,
+            500,
+            500,
+            500,
+            500,
+            500,
+            "/bin/cat",
+            "7fffd19c5592"
+        },
+
+        // Execve record data
+        {
+        },
+
+        // Path record data
+        {
+            {
+                {
+                    "/etc/ssh/sshd_config",
+                    0100600,
+                    0,
+                    0,
+                    409242
+                }
+            }
+        },
+
+        // Cwd data
+        {
+            "/home/wajih"
+        },
+
+        // Sockaddr data
+        {}
+    };
+    // clang-format on
+    WHEN("generating a table row") {
+      IVirtualTable::Row row;
+      auto status = FileEventsTablePlugin::generateRow(row, kCreateAuditEvent);
+
+      REQUIRE(status.succeeded());
+
+      THEN("rows are generated correctly") {
+        static ExpectedValueList kExpectedColumnList = {
+            {"syscall", "open"},
+            {"pid", kCreateAuditEvent.syscall_data.process_id},
+            {"ppid", kCreateAuditEvent.syscall_data.parent_process_id},
+            {"uid", kCreateAuditEvent.syscall_data.uid},
+            {"gid", kCreateAuditEvent.syscall_data.gid},
+            {"auid", kCreateAuditEvent.syscall_data.auid},
+            {"euid", kCreateAuditEvent.syscall_data.euid},
+            {"egid", kCreateAuditEvent.syscall_data.egid},
+            {"exe", "/bin/cat"},
+            {"path", "/etc/ssh/sshd_config"},
+            {"inode", static_cast<std::int64_t>(409242)}};
+
+        REQUIRE(row.size() == kExpectedColumnList.size() + 1);
+
+        REQUIRE(row.count("time") != 0U);
+        REQUIRE(row.at("time").has_value());
+
+        validateRow(row, kExpectedColumnList);
+      }
+    }
+  }
+
+  GIVEN("a valid openat syscall audit event") {
+    // clang-format off
+    static const IAudispConsumer::AuditEvent kCreateAuditEvent = {
+        // Syscall record data
+        {
+            IAudispConsumer::SyscallRecordData::Type::OpenAt,
+            0,
+            38031,
+            38030,
+            true,
+            1000,
+            1000,
+            1000,
+            1000,
+            1000,
+            "/home/wajih/a.out",
+            "ffffff9c"
+        },
+
+        // Execve record data
+        {
+        },
+
+        // Path record data
+        {
+            {
+                {
+                    "/home/wajih",
+                    040755,
+                    1000,
+                    1000,
+                    786436
+                },
+                {
+                    "file.txt",
+                    0102430,
+                    1000,
+                    1000,
+                    806807
+                }
+            }
+        },
+
+        // Cwd data
+        {
+            "/home/wajih"
+        },
+
+        // Sockaddr data
+        {}
+    };
+    // clang-format on
+    WHEN("generating a table row") {
+      IVirtualTable::Row row;
+      auto status = FileEventsTablePlugin::generateRow(row, kCreateAuditEvent);
+
+      REQUIRE(status.succeeded());
+
+      THEN("rows are generated correctly") {
+        static ExpectedValueList kExpectedColumnList = {
+            {"syscall", "openat"},
+            {"pid", kCreateAuditEvent.syscall_data.process_id},
+            {"ppid", kCreateAuditEvent.syscall_data.parent_process_id},
+            {"uid", kCreateAuditEvent.syscall_data.uid},
+            {"gid", kCreateAuditEvent.syscall_data.gid},
+            {"auid", kCreateAuditEvent.syscall_data.auid},
+            {"euid", kCreateAuditEvent.syscall_data.euid},
+            {"egid", kCreateAuditEvent.syscall_data.egid},
+            {"exe", "/home/wajih/a.out"},
+            {"path", "/home/wajih/file.txt"},
+            {"inode", static_cast<std::int64_t>(806807)}};
+
+        REQUIRE(row.size() == kExpectedColumnList.size() + 1);
+
+        REQUIRE(row.count("time") != 0U);
+        REQUIRE(row.at("time").has_value());
+
+        validateRow(row, kExpectedColumnList);
+      }
+    }
+  }
+}
+} // namespace zeek

--- a/tables/audisp/tests/processeventstableplugin.cpp
+++ b/tables/audisp/tests/processeventstableplugin.cpp
@@ -22,8 +22,8 @@ SCENARIO("Row generation in the process_events table",
         1000,
         1000,
         1000,
-        "23eb8e0",
-        "\"/usr/bin/bash\""
+        "\"/usr/bin/bash\"",
+        "23eb8e0"
       },
 
       // Execve record data
@@ -44,14 +44,16 @@ SCENARIO("Row generation in the process_events table",
             "/usr/bin/bash",
             0755,
             0,
-            0
+            0,
+           806807
           },
 
           {
             "/lib64/ld-linux-x86-64.so.2",
             0755,
             0,
-            0
+            0,
+           786436,
           }
         }
       },
@@ -74,25 +76,24 @@ SCENARIO("Row generation in the process_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedColumnList = {
-          { "syscall", "execve" },
-          { "pid", kExecveAuditEvent.syscall_data.process_id },
-          { "parent", kExecveAuditEvent.syscall_data.parent_process_id },
-          { "auid", kExecveAuditEvent.syscall_data.auid },
-          { "uid", kExecveAuditEvent.syscall_data.uid },
-          { "euid", kExecveAuditEvent.syscall_data.euid },
-          { "gid", kExecveAuditEvent.syscall_data.gid },
-          { "egid", kExecveAuditEvent.syscall_data.egid },
-          { "owner_uid", static_cast<std::int64_t>(0) },
-          { "owner_gid", static_cast<std::int64_t>(0) },
-          { "cmdline_size", static_cast<std::int64_t>(24) },
-          { "cmdline", "\"-c\" \"echo hello world!\"" },
-          { "path", "/usr/bin/bash" },
-          { "mode", static_cast<std::int64_t>(0755) },
-          { "cwd", "/root" }
-        };
-        // clang-format on
+            {"syscall", "execve"},
+            {"pid", kExecveAuditEvent.syscall_data.process_id},
+            {"ppid", kExecveAuditEvent.syscall_data.parent_process_id},
+            {"auid", kExecveAuditEvent.syscall_data.auid},
+            {"uid", kExecveAuditEvent.syscall_data.uid},
+            {"euid", kExecveAuditEvent.syscall_data.euid},
+            {"gid", kExecveAuditEvent.syscall_data.gid},
+            {"egid", kExecveAuditEvent.syscall_data.egid},
+            {"exe", kExecveAuditEvent.syscall_data.exe},
+            {"exit", kExecveAuditEvent.syscall_data.exit_code},
+            {"cmdline", "\"-c\" \"echo hello world!\""},
+            {"path", "/usr/bin/bash"},
+            {"mode", static_cast<std::int64_t>(0755)},
+            {"ouid", static_cast<std::int64_t>(0)},
+            {"ogid", static_cast<std::int64_t>(0)},
+            {"inode", static_cast<std::int64_t>(806807)},
+            {"cwd", "/root"}};
 
         REQUIRE(row.size() == kExpectedColumnList.size() + 1);
 
@@ -119,8 +120,8 @@ SCENARIO("Row generation in the process_events table",
         1000,
         1000,
         1000,
-        "23eb8e0",
-        "\"/usr/bin/bash\""
+        "\"/usr/bin/bash\"",
+        "23eb8e0"
       },
 
       // Execve record data
@@ -144,25 +145,24 @@ SCENARIO("Row generation in the process_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedForkColumnList = {
-          { "syscall", "fork" },
-          { "pid", kForkAuditEvent.syscall_data.process_id },
-          { "parent", kForkAuditEvent.syscall_data.parent_process_id },
-          { "auid", kForkAuditEvent.syscall_data.auid },
-          { "uid", kForkAuditEvent.syscall_data.uid },
-          { "euid", kForkAuditEvent.syscall_data.euid },
-          { "gid", kForkAuditEvent.syscall_data.gid },
-          { "egid", kForkAuditEvent.syscall_data.egid },
-          { "owner_uid", { static_cast<std::int64_t>(0) } },
-          { "owner_gid", { static_cast<std::int64_t>(0) } },
-          { "cmdline_size", { static_cast<std::int64_t>(0) } },
-          { "cmdline", { "" } },
-          { "path", { "" } },
-          { "mode", { static_cast<std::int64_t>(0) } },
-          { "cwd", { "" } }
-        };
-        // clang-format on
+            {"syscall", "fork"},
+            {"pid", kForkAuditEvent.syscall_data.process_id},
+            {"ppid", kForkAuditEvent.syscall_data.parent_process_id},
+            {"auid", kForkAuditEvent.syscall_data.auid},
+            {"uid", kForkAuditEvent.syscall_data.uid},
+            {"euid", kForkAuditEvent.syscall_data.euid},
+            {"gid", kForkAuditEvent.syscall_data.gid},
+            {"egid", kForkAuditEvent.syscall_data.egid},
+            {"exe", kForkAuditEvent.syscall_data.exe},
+            {"exit", kForkAuditEvent.syscall_data.exit_code},
+            {"cmdline", {""}},
+            {"path", {""}},
+            {"mode", static_cast<std::int64_t>(0)},
+            {"ouid", static_cast<std::int64_t>(0)},
+            {"ogid", static_cast<std::int64_t>(0)},
+            {"inode", static_cast<std::int64_t>(0)},
+            {"cwd", {""}}};
 
         REQUIRE(row.size() == kExpectedForkColumnList.size() + 1);
         REQUIRE(row.count("time") != 0U);
@@ -188,8 +188,8 @@ SCENARIO("Row generation in the process_events table",
         2000,
         2000,
         2000,
-        "23eb8e0",
-        "\"/usr/bin/bash\""
+        "\"/usr/bin/bash\"",
+        "23eb8e0"
       },
 
       // Execve record data
@@ -214,25 +214,24 @@ SCENARIO("Row generation in the process_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedVForkColumnList = {
-          { "syscall", "vfork" },
-          { "pid", kVForkAuditEvent.syscall_data.process_id },
-          { "parent", kVForkAuditEvent.syscall_data.parent_process_id },
-          { "auid", kVForkAuditEvent.syscall_data.auid },
-          { "uid", kVForkAuditEvent.syscall_data.uid },
-          { "euid", kVForkAuditEvent.syscall_data.euid },
-          { "gid", kVForkAuditEvent.syscall_data.gid },
-          { "egid", kVForkAuditEvent.syscall_data.egid },
-          { "owner_uid", { static_cast<std::int64_t>(0) } },
-          { "owner_gid", { static_cast<std::int64_t>(0) } },
-          { "cmdline_size", { static_cast<std::int64_t>(0) } },
-          { "cmdline", { "" } },
-          { "path", { "" } },
-          { "mode", { static_cast<std::int64_t>(0) } },
-          { "cwd", { "" } }
-        };
-        // clang-format on
+            {"syscall", "vfork"},
+            {"pid", kVForkAuditEvent.syscall_data.process_id},
+            {"ppid", kVForkAuditEvent.syscall_data.parent_process_id},
+            {"auid", kVForkAuditEvent.syscall_data.auid},
+            {"uid", kVForkAuditEvent.syscall_data.uid},
+            {"euid", kVForkAuditEvent.syscall_data.euid},
+            {"gid", kVForkAuditEvent.syscall_data.gid},
+            {"egid", kVForkAuditEvent.syscall_data.egid},
+            {"exe", kVForkAuditEvent.syscall_data.exe},
+            {"exit", kVForkAuditEvent.syscall_data.exit_code},
+            {"cmdline", {""}},
+            {"path", {""}},
+            {"mode", static_cast<std::int64_t>(0)},
+            {"ouid", static_cast<std::int64_t>(0)},
+            {"ogid", static_cast<std::int64_t>(0)},
+            {"inode", static_cast<std::int64_t>(0)},
+            {"cwd", {""}}};
 
         REQUIRE(row.size() == kExpectedVForkColumnList.size() + 1);
         REQUIRE(row.count("time") != 0U);
@@ -258,8 +257,8 @@ SCENARIO("Row generation in the process_events table",
         3000,
         3000,
         3000,
-        "23eb8e0",
-        "\"/usr/bin/bash\""
+        "\"/usr/bin/bash\"",
+        "23eb8e0"
       },
 
       // Execve record data
@@ -284,25 +283,24 @@ SCENARIO("Row generation in the process_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedCloneColumnList = {
-          { "syscall", "clone" },
-          { "pid", kCloneAuditEvent.syscall_data.process_id },
-          { "parent", kCloneAuditEvent.syscall_data.parent_process_id },
-          { "auid", kCloneAuditEvent.syscall_data.auid },
-          { "uid", kCloneAuditEvent.syscall_data.uid },
-          { "euid", kCloneAuditEvent.syscall_data.euid },
-          { "gid", kCloneAuditEvent.syscall_data.gid },
-          { "egid", kCloneAuditEvent.syscall_data.egid },
-          { "owner_uid", { static_cast<std::int64_t>(0) } },
-          { "owner_gid", { static_cast<std::int64_t>(0) } },
-          { "cmdline_size", { static_cast<std::int64_t>(0) } },
-          { "cmdline", { "" } },
-          { "path", { "" } },
-          { "mode", { static_cast<std::int64_t>(0) } },
-          { "cwd", { "" } }
-        };
-        // clang-format on
+            {"syscall", "clone"},
+            {"pid", kCloneAuditEvent.syscall_data.process_id},
+            {"ppid", kCloneAuditEvent.syscall_data.parent_process_id},
+            {"auid", kCloneAuditEvent.syscall_data.auid},
+            {"uid", kCloneAuditEvent.syscall_data.uid},
+            {"euid", kCloneAuditEvent.syscall_data.euid},
+            {"gid", kCloneAuditEvent.syscall_data.gid},
+            {"egid", kCloneAuditEvent.syscall_data.egid},
+            {"exe", kCloneAuditEvent.syscall_data.exe},
+            {"exit", kCloneAuditEvent.syscall_data.exit_code},
+            {"cmdline", {""}},
+            {"path", {""}},
+            {"mode", static_cast<std::int64_t>(0)},
+            {"ouid", static_cast<std::int64_t>(0)},
+            {"ogid", static_cast<std::int64_t>(0)},
+            {"inode", static_cast<std::int64_t>(0)},
+            {"cwd", {""}}};
 
         REQUIRE(row.size() == kExpectedCloneColumnList.size() + 1);
         REQUIRE(row.count("time") != 0U);

--- a/tables/audisp/tests/socketeventstableplugin.cpp
+++ b/tables/audisp/tests/socketeventstableplugin.cpp
@@ -54,21 +54,23 @@ SCENARIO("Row generation in the socket_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedConnectColumnList = {
-          { "action", "connect" },
-          { "pid", static_cast<std::int64_t>(38031) },
-          { "path", "/usr/bin/curl" },
-          { "fd", static_cast<std::int64_t>(16) },
-          { "auid", static_cast<std::int64_t>(1000) },
-          { "success", static_cast<std::int64_t>(1) },
-          { "family", static_cast<std::int64_t>(2) },
-          { "local_address", { "" } },
-          { "remote_address", "127.0.0.1" },
-          { "local_port", { static_cast<std::int64_t>(0) } },
-          { "remote_port", static_cast<std::int64_t>(443) }
-        };
-        // clang-format on
+            {"syscall", "connect"},
+            {"pid", kConnectAuditEvent.syscall_data.process_id},
+            {"ppid", kConnectAuditEvent.syscall_data.parent_process_id},
+            {"auid", kConnectAuditEvent.syscall_data.auid},
+            {"uid", kConnectAuditEvent.syscall_data.uid},
+            {"euid", kConnectAuditEvent.syscall_data.euid},
+            {"gid", kConnectAuditEvent.syscall_data.gid},
+            {"egid", kConnectAuditEvent.syscall_data.egid},
+            {"exe", "/usr/bin/curl"},
+            {"fd", static_cast<std::int64_t>(16)},
+            {"success", static_cast<std::int64_t>(1)},
+            {"family", static_cast<std::int64_t>(2)},
+            {"local_address", {""}},
+            {"remote_address", "127.0.0.1"},
+            {"local_port", {static_cast<std::int64_t>(0)}},
+            {"remote_port", static_cast<std::int64_t>(443)}};
 
         REQUIRE(row.size() == kExpectedConnectColumnList.size() + 1);
         REQUIRE(row.count("time") != 0U);
@@ -125,21 +127,23 @@ SCENARIO("Row generation in the socket_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedBindColumnList = {
-          { "action", "bind" },
-          { "pid", static_cast<std::int64_t>(38031) },
-          { "path", "/usr/bin/curl" },
-          { "fd", static_cast<std::int64_t>(16) },
-          { "auid", static_cast<std::int64_t>(1000) },
-          { "success", static_cast<std::int64_t>(1) },
-          { "family", static_cast<std::int64_t>(2) },
-          { "local_address", "0.0.0.0" },
-          { "remote_address", { "" } },
-          { "local_port", static_cast<std::int64_t>(8080) },
-          { "remote_port", { static_cast<std::int64_t>(0) } }
-        };
-        // clang-format on
+            {"syscall", "bind"},
+            {"pid", kBindAuditEvent.syscall_data.process_id},
+            {"ppid", kBindAuditEvent.syscall_data.parent_process_id},
+            {"auid", kBindAuditEvent.syscall_data.auid},
+            {"uid", kBindAuditEvent.syscall_data.uid},
+            {"euid", kBindAuditEvent.syscall_data.euid},
+            {"gid", kBindAuditEvent.syscall_data.gid},
+            {"egid", kBindAuditEvent.syscall_data.egid},
+            {"exe", "/usr/bin/curl"},
+            {"fd", static_cast<std::int64_t>(16)},
+            {"success", static_cast<std::int64_t>(1)},
+            {"family", static_cast<std::int64_t>(2)},
+            {"local_address", "0.0.0.0"},
+            {"remote_address", {""}},
+            {"local_port", static_cast<std::int64_t>(8080)},
+            {"remote_port", {static_cast<std::int64_t>(0)}}};
 
         REQUIRE(row.size() == kExpectedBindColumnList.size() + 1);
         REQUIRE(row.count("time") != 0U);


### PR DESCRIPTION
This PR basically adds/updates following three big things:

1. Adds a file events table `fileeventstableplugin.cpp` for Linux platform. Currently, it handles `creat`, `open`, and `openat` syscalls. I have also added tests that generate file event logs and then check table rows generated by zeek-agent for data correctness.

2. Updates column names for all three tables (process, socket, and file) so that those column names match the key names that appear in the underlying `auditd` logs. For example, it replaces "parent" column name with "ppid" because `auditd` log uses "ppid" key name to represent parent's pid. I also updated the variable names in `processeventstableplugin.cpp`, `socketeventstableplugin.cpp`, and `fileeventstableplugin.cpp` files so that they are consistent and match across tables. 

3. Incorporates requested changes on macOS event tables in PR#67 that are also applicable here to Linux event tables.