### PR TITLE
Add OpenBSM service to collect socket events on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # Zeek Agent
 
-The *Zeek Agent* is an endpoint monitoring tool for Linux that
-reports, by default, socket and process events to
-[Zeek](https://zeek.org). Event data is captured from Audit using the
-Unix domain socket plugin that comes with Audisp, and is then
-presented to Zeek as an SQL database (using SQLite virtual tables
-internally).
+The *Zeek Agent* is an endpoint monitoring tool for Linux and macOS that
+reports, by default, file, socket, and process events to
+[Zeek](https://zeek.org). On Linux, event data is captured from [Linux
+Audit](https://linux.die.net/man/8/auditd) using the Unix domain socket plugin
+that comes with [Audisp](https://linux.die.net/man/8/audispd). On macOS,
+Zeek Agent leverages [Endpoint
+Security](https://developer.apple.com/documentation/endpointsecurity) framework
+to capture file and process events while to collect socket events Zeek Agent
+uses [OpenBSM](http://www.trustedbsd.org/openbsm.html).  Collected event data
+from endpoint is stored in an SQL database (using SQLite virtual tables
+internally) on the host. Events from this database are later fetched by Zeek
+using scheduled queries.
 
-Zeek-Agent can optionally also interface to
-[osquery](https://www.osquery.io), allowing Zeek to access almost all
-the endpoint information that it provides (excluding only evented
-tables).
+Zeek Agent can optionally also interface to [osquery](https://www.osquery.io),
+allowing Zeek to access almost all the endpoint information that it provides
+(excluding only event tables).
 
 Pre-built, statically linked `zeek-agent` packages are available on
 the [releases page](https://github.com/zeek/zeek-agent/releases).
@@ -24,9 +29,9 @@ endpoint activity into Zeek logs.
 
 The documentation has been moved to the [Zeek Agent
 Wiki](https://github.com/zeek/zeek-agent/wiki), and contains
-guides on building, configuring and extending the Zeek Agent project.
+guides on building, configuring, and extending the Zeek Agent project.
 
-For convenience, the build and configuration guides can be accessed from the following links:
+For convenience, use the following links to build and configure Zeek Agent:
 - [Build Guide](https://github.com/zeek/zeek-agent/wiki/Build-Guide)
 - [Configuration Guide](https://github.com/zeek/zeek-agent/wiki/Configuration-Guide)
 

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -11,6 +11,7 @@ function(zeekComponents)
     add_subdirectory("zeekaudisp")
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     add_subdirectory("zeekendpointsecurity")
+    add_subdirectory("zeekopenbsm")
   endif()
 
   if(TARGET osqueryd)

--- a/components/zeekaudisp/include/zeek/iaudispconsumer.h
+++ b/components/zeekaudisp/include/zeek/iaudispconsumer.h
@@ -13,7 +13,18 @@ public:
   /// \brief SYSCALL record data
   struct SyscallRecordData final {
     /// \brief Supported syscalls
-    enum class Type { Execve, ExecveAt, Fork, VFork, Clone, Bind, Connect };
+    enum class Type {
+      Execve,
+      ExecveAt,
+      Fork,
+      VFork,
+      Clone,
+      Bind,
+      Connect,
+      Open,
+      OpenAt,
+      Create
+    };
 
     /// \brief Event type
     Type type;
@@ -83,6 +94,9 @@ public:
 
     /// \brief Owner group id
     std::int64_t ogid{0};
+
+    /// \brief File Inode
+    std::int64_t inode{0};
   };
 
   /// \brief A list of PATH records

--- a/components/zeekendpointsecurity/include/zeek/iendpointsecurityconsumer.h
+++ b/components/zeekendpointsecurity/include/zeek/iendpointsecurityconsumer.h
@@ -10,7 +10,7 @@
 #include <unistd.h>
 
 namespace zeek {
-/// \brief Audisp socket consumer (interface)
+/// \brief EndpointSecurity consumer (interface)
 class IEndpointSecurityConsumer {
 public:
   /// \brief Event data
@@ -49,10 +49,13 @@ public:
 
       /// \brief Program path
       std::string path;
+
+      /// \brief File path
+      std::string file_path;
     };
 
     /// \brief Supported event types
-    enum class Type { Fork, Exec };
+    enum class Type { Fork, Exec, Open, Create };
 
     /// \brief Exec event data
     struct ExecEventData final {

--- a/components/zeekendpointsecurity/src/endpointsecurityconsumer.h
+++ b/components/zeekendpointsecurity/src/endpointsecurityconsumer.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <vector>
 
+#include <EndpointSecurity/EndpointSecurity.h>
 #include <zeek/iendpointsecurityconsumer.h>
 
 namespace zeek {
@@ -26,28 +27,44 @@ private:
                            IZeekConfiguration &configuration);
 
   /// \brief Event callback used by EndpointSecurity
-  void endpointSecurityCallback(const void *message_ptr);
+  void endpointSecurityCallback(const es_message_t &message);
 
 public:
   /// \brief Initializes the event header from the given message
   /// \param event_header The event header object to initialize
-  /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
+  /// \param message a reference to an EndpointSecurity es_message_t object
   /// \return A Status object
   static Status initializeEventHeader(Event::Header &event_header,
-                                      const void *message_ptr);
+                                      const es_message_t &message);
 
   /// \brief Process execution event handler
   /// \param event the generated event object
-  /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
+  /// \param message a reference to EndpointSecurity es_message_t object
   /// \return A Status object
-  static Status processExecNotification(Event &event, const void *message_ptr);
+  static Status processExecNotification(Event &event,
+                                        const es_message_t &message);
 
   /// \brief Process forking event handler
   /// \param event the generated event object
-  /// \param message_ptr a valid pointer to an EndpointSecurity es_message_t
+  /// \param message a reference to an EndpointSecurity es_message_t object
   /// \return A Status object
-  static Status processForkNotification(Event &event, const void *message_ptr);
+  static Status processForkNotification(Event &event,
+                                        const es_message_t &message);
 
   friend class IEndpointSecurityConsumer;
+
+  /// \brief File open event handler
+  /// \param event the generated event object
+  /// \param message a reference to an EndpointSecurity es_message_t object
+  /// \return A Status object
+  static Status processOpenNotification(Event &event,
+                                        const es_message_t &message);
+
+  /// \brief File create event handler
+  /// \param event the generated event object
+  /// \param message a reference to an EndpointSecurity es_message_t object
+  /// \return A Status object
+  static Status processCreateNotification(Event &event,
+                                          const es_message_t &message);
 };
 } // namespace zeek

--- a/components/zeekendpointsecurity/tests/endpointsecurityconsumer.cpp
+++ b/components/zeekendpointsecurity/tests/endpointsecurityconsumer.cpp
@@ -5,10 +5,10 @@
 #include <catch2/catch.hpp>
 
 #include <EndpointSecurity/EndpointSecurity.h>
-#include <bsm/libbsm.h>
 
 namespace zeek {
-TEST_CASE("Event header initialization", "[ZeekEndpointConsumer]") {
+TEST_CASE("Event header initialization for Exec Event",
+          "[ZeekEndpointConsumer]") {
   es_process_t process = {};
   process.ppid = 10U;
   process.original_ppid = 11U;
@@ -44,20 +44,215 @@ TEST_CASE("Event header initialization", "[ZeekEndpointConsumer]") {
 
   IEndpointSecurityConsumer::Event::Header header;
   auto status =
-      EndpointSecurityConsumer::initializeEventHeader(header, &es_message);
+      EndpointSecurityConsumer::initializeEventHeader(header, es_message);
 
   REQUIRE(status.succeeded());
 
-  REQUIRE(header.timestamp != 0U);
-  REQUIRE(header.parent_process_id == 10U);
-  REQUIRE(header.orig_parent_process_id == 11U);
-  REQUIRE(header.process_id == 245U);
-  REQUIRE(header.user_id == 241U);
-  REQUIRE(header.group_id == 242U);
-  REQUIRE(header.platform_binary == 1U);
-  REQUIRE(header.signing_id == kDummySigningIdentifier);
-  REQUIRE(header.team_id == kDummyTeamIdentifier);
-  REQUIRE(header.path == kDummyPath);
-  REQUIRE(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+  CHECK(header.timestamp != 0U);
+  CHECK(header.parent_process_id == 10U);
+  CHECK(header.orig_parent_process_id == 11U);
+  CHECK(header.process_id == 245U);
+  CHECK(header.user_id == 241U);
+  CHECK(header.group_id == 242U);
+  CHECK(header.platform_binary == 1U);
+  CHECK(header.signing_id == kDummySigningIdentifier);
+  CHECK(header.team_id == kDummyTeamIdentifier);
+  CHECK(header.path == kDummyPath);
+  CHECK(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+}
+
+TEST_CASE("Event header initialization for Open event",
+          "[ZeekEndpointConsumer]") {
+  es_process_t process = {};
+  process.ppid = 10U;
+  process.original_ppid = 11U;
+
+  for (auto i = 0U; i < 8U; ++i) {
+    process.audit_token.val[i] = 0xF0U + i;
+  }
+
+  process.is_platform_binary = 1U;
+
+  for (auto i = 0U; i < sizeof(process.cdhash); ++i) {
+    process.cdhash[i] = 0xA0U + i;
+  }
+
+  const char *kDummySigningIdentifier = "SigningID";
+  process.signing_id.data = kDummySigningIdentifier;
+  process.signing_id.length = std::strlen(kDummySigningIdentifier);
+
+  const char *kDummyTeamIdentifier = "TeamID";
+  process.team_id.data = kDummyTeamIdentifier;
+  process.team_id.length = std::strlen(kDummyTeamIdentifier);
+
+  const char *kDummyPath = "/path/to/application";
+  es_file_t executable = {};
+  executable.path.data = kDummyPath;
+  executable.path.length = std::strlen(kDummyPath);
+
+  process.executable = &executable;
+
+  es_message_t es_message = {};
+  es_message.event_type = ES_EVENT_TYPE_NOTIFY_OPEN;
+  es_message.process = &process;
+
+  const char *kDummyFilePath = "/path/to/file";
+  es_file_t file = {};
+  file.path.data = kDummyFilePath;
+  file.path.length = std::strlen(kDummyFilePath);
+
+  es_message.event.open.file = &file;
+
+  IEndpointSecurityConsumer::Event::Header header;
+  auto status =
+      EndpointSecurityConsumer::initializeEventHeader(header, es_message);
+
+  REQUIRE(status.succeeded());
+
+  CHECK(header.timestamp != 0U);
+  CHECK(header.parent_process_id == 10U);
+  CHECK(header.orig_parent_process_id == 11U);
+  CHECK(header.process_id == 245U);
+  CHECK(header.user_id == 241U);
+  CHECK(header.group_id == 242U);
+  CHECK(header.platform_binary == 1U);
+  CHECK(header.signing_id == kDummySigningIdentifier);
+  CHECK(header.team_id == kDummyTeamIdentifier);
+  CHECK(header.path == kDummyPath);
+  CHECK(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+  CHECK(header.file_path == kDummyFilePath);
+}
+
+TEST_CASE("Event header initialization for Create event with existing path",
+          "[ZeekEndpointConsumer]") {
+  es_process_t process = {};
+  process.ppid = 10U;
+  process.original_ppid = 11U;
+
+  for (auto i = 0U; i < 8U; ++i) {
+    process.audit_token.val[i] = 0xF0U + i;
+  }
+
+  process.is_platform_binary = 1U;
+
+  for (auto i = 0U; i < sizeof(process.cdhash); ++i) {
+    process.cdhash[i] = 0xA0U + i;
+  }
+
+  const char *kDummySigningIdentifier = "SigningID";
+  process.signing_id.data = kDummySigningIdentifier;
+  process.signing_id.length = std::strlen(kDummySigningIdentifier);
+
+  const char *kDummyTeamIdentifier = "TeamID";
+  process.team_id.data = kDummyTeamIdentifier;
+  process.team_id.length = std::strlen(kDummyTeamIdentifier);
+
+  const char *kDummyPath = "/path/to/application";
+  es_file_t executable = {};
+  executable.path.data = kDummyPath;
+  executable.path.length = std::strlen(kDummyPath);
+
+  process.executable = &executable;
+
+  es_message_t es_message = {};
+  es_message.event_type = ES_EVENT_TYPE_NOTIFY_CREATE;
+  es_message.event.create.destination_type = ES_DESTINATION_TYPE_NEW_PATH;
+  es_message.process = &process;
+
+  const char *kDummyFilePath = "/path/to/file";
+
+  const char *kDummyDir = "/path/to";
+  es_file_t newPathDir = {};
+  newPathDir.path.data = kDummyDir;
+  newPathDir.path.length = std::strlen(kDummyDir);
+
+  es_message.event.create.destination.new_path.dir = &newPathDir;
+
+  const char *kDummyFilename = "file";
+  es_message.event.create.destination.new_path.filename.data = kDummyFilename;
+  es_message.event.create.destination.new_path.filename.length =
+      std::strlen(kDummyFilename);
+
+  IEndpointSecurityConsumer::Event::Header header;
+  auto status =
+      EndpointSecurityConsumer::initializeEventHeader(header, es_message);
+
+  REQUIRE(status.succeeded());
+
+  CHECK(header.timestamp != 0U);
+  CHECK(header.parent_process_id == 10U);
+  CHECK(header.orig_parent_process_id == 11U);
+  CHECK(header.process_id == 245U);
+  CHECK(header.user_id == 241U);
+  CHECK(header.group_id == 242U);
+  CHECK(header.platform_binary == 1U);
+  CHECK(header.signing_id == kDummySigningIdentifier);
+  CHECK(header.team_id == kDummyTeamIdentifier);
+  CHECK(header.path == kDummyPath);
+  CHECK(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+  CHECK(header.file_path == kDummyFilePath);
+}
+
+TEST_CASE("Event header initialization for Create event with new path",
+          "[ZeekEndpointConsumer]") {
+  es_process_t process = {};
+  process.ppid = 10U;
+  process.original_ppid = 11U;
+
+  for (auto i = 0U; i < 8U; ++i) {
+    process.audit_token.val[i] = 0xF0U + i;
+  }
+
+  process.is_platform_binary = 1U;
+
+  for (auto i = 0U; i < sizeof(process.cdhash); ++i) {
+    process.cdhash[i] = 0xA0U + i;
+  }
+
+  const char *kDummySigningIdentifier = "SigningID";
+  process.signing_id.data = kDummySigningIdentifier;
+  process.signing_id.length = std::strlen(kDummySigningIdentifier);
+
+  const char *kDummyTeamIdentifier = "TeamID";
+  process.team_id.data = kDummyTeamIdentifier;
+  process.team_id.length = std::strlen(kDummyTeamIdentifier);
+
+  const char *kDummyPath = "/path/to/application";
+  es_file_t executable = {};
+  executable.path.data = kDummyPath;
+  executable.path.length = std::strlen(kDummyPath);
+
+  process.executable = &executable;
+
+  es_message_t es_message = {};
+  es_message.event_type = ES_EVENT_TYPE_NOTIFY_CREATE;
+  es_message.event.create.destination_type = ES_DESTINATION_TYPE_EXISTING_FILE;
+  es_message.process = &process;
+
+  const char *kDummyFilePath = "/path/to/file";
+  es_file_t existing_file = {};
+  existing_file.path.data = kDummyFilePath;
+  existing_file.path.length = std::strlen(kDummyFilePath);
+
+  es_message.event.create.destination.existing_file = &existing_file;
+
+  IEndpointSecurityConsumer::Event::Header header;
+  auto status =
+      EndpointSecurityConsumer::initializeEventHeader(header, es_message);
+
+  REQUIRE(status.succeeded());
+
+  CHECK(header.timestamp != 0U);
+  CHECK(header.parent_process_id == 10U);
+  CHECK(header.orig_parent_process_id == 11U);
+  CHECK(header.process_id == 245U);
+  CHECK(header.user_id == 241U);
+  CHECK(header.group_id == 242U);
+  CHECK(header.platform_binary == 1U);
+  CHECK(header.signing_id == kDummySigningIdentifier);
+  CHECK(header.team_id == kDummyTeamIdentifier);
+  CHECK(header.path == kDummyPath);
+  CHECK(header.cdhash == "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+  CHECK(header.file_path == kDummyFilePath);
 }
 } // namespace zeek

--- a/components/zeekopenbsm/CMakeLists.txt
+++ b/components/zeekopenbsm/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.16.3)
+project("zeek_openbsm")
+
+function(zeekAgentComponentsOpenbsm)
+  add_library("${PROJECT_NAME}"
+          include/zeek/iopenbsmconsumer.h
+
+          src/openbsmconsumer.h
+          src/openbsmconsumer.cpp
+
+          src/openbsm_utils.h
+          src/openbsm_utils.cpp
+  )
+
+  importLibraries()
+
+  target_link_libraries("${PROJECT_NAME}"
+    PRIVATE
+      zeek_agent_cxx_settings
+
+    PUBLIC
+      zeek_utils
+      zeek_logger
+      zeek_configuration
+
+      thirdparty_openbsm
+  )
+
+  target_include_directories("${PROJECT_NAME}"
+    PRIVATE include
+  )
+
+  target_include_directories("${PROJECT_NAME}"
+    SYSTEM INTERFACE include
+  )
+
+  generateZeekAgentTest(
+    SOURCE_TARGET
+      "${PROJECT_NAME}"
+
+    SOURCES
+      tests/main.cpp
+          tests/openbsmconsumer.cpp
+  )
+endfunction()
+
+function(importExternalLibrary target_name library_name)
+  set(library_path_var "${library_name}_path")
+
+  find_library("${library_path_var}" "${library_name}"
+    PATHS "${CMAKE_OSX_SYSROOT}/usr/lib"
+  )
+
+  if("${${library_path_var}}" STREQUAL "${library_path_var}-NOTFOUND")
+    message(FATAL_ERROR "The ${target_name} (${library_name}) library was not found")
+  endif()
+
+  add_library("thirdparty_${target_name}" STATIC IMPORTED GLOBAL)
+  set_target_properties("thirdparty_${target_name}" PROPERTIES
+    IMPORTED_LOCATION "${${library_path_var}}"
+  )
+endfunction()
+
+function(importLibraries)
+  importExternalLibrary("openbsm" "libbsm.tbd")
+endfunction()
+
+zeekAgentComponentsOpenbsm()
+

--- a/components/zeekopenbsm/CMakeLists.txt
+++ b/components/zeekopenbsm/CMakeLists.txt
@@ -3,13 +3,13 @@ project("zeek_openbsm")
 
 function(zeekAgentComponentsOpenbsm)
   add_library("${PROJECT_NAME}"
-          include/zeek/iopenbsmconsumer.h
+      include/zeek/iopenbsmconsumer.h
 
-          src/openbsmconsumer.h
-          src/openbsmconsumer.cpp
+      src/openbsmconsumer.h
+      src/openbsmconsumer.cpp
 
-          src/openbsm_utils.h
-          src/openbsm_utils.cpp
+      src/openbsm_utils.h
+      src/openbsm_utils.cpp
   )
 
   importLibraries()
@@ -66,4 +66,3 @@ function(importLibraries)
 endfunction()
 
 zeekAgentComponentsOpenbsm()
-

--- a/components/zeekopenbsm/include/zeek/iopenbsmconsumer.h
+++ b/components/zeekopenbsm/include/zeek/iopenbsmconsumer.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <memory>
+#include <unistd.h>
+#include <variant>
+#include <vector>
+
+#include <zeek/izeekconfiguration.h>
+#include <zeek/izeeklogger.h>
+
+namespace zeek {
+/// \brief OpenBSM consumer (interface)
+class IOpenbsmConsumer {
+public:
+  /// \brief Event data
+  struct Event final {
+    /// \brief Event header
+    struct Header final {
+      /// \brief Event timestamp
+      std::uint64_t timestamp{};
+
+      /// \brief Process id
+      pid_t process_id{};
+
+      /// \brief User id
+      uid_t user_id{};
+
+      /// \brief Group id
+      gid_t group_id{};
+
+      /// \brief Program path
+      std::string path;
+
+      /// \brief success
+      int success;
+
+      /// \brief remote ip address
+      std::string remote_address;
+
+      /// \brief remote port number
+      int remote_port;
+
+      /// \brief local ip address
+      std::string local_address;
+
+      /// \brief local port number
+      int local_port;
+
+      /// \brief protocol family
+      int family;
+    };
+
+    /// \brief Supported event types
+    enum class Type { Connect, Bind };
+
+    /// \brief Event type
+    Type type;
+
+    /// \brief Event header
+    Header header;
+  };
+
+  /// \brief A list of events
+  using EventList = std::vector<Event>;
+
+  /// \brief A unique_ptr to an IOpenbsmConsumer
+  using Ref = std::unique_ptr<IOpenbsmConsumer>;
+
+  /// \brief Factory method
+  /// \param obj where the created object is stored
+  /// \param logger an initialized logger object
+  /// \param configuration an initialized configuration object
+  /// \return A Status object
+  static Status create(Ref &obj, IZeekLogger &logger,
+                       IZeekConfiguration &configuration);
+
+  /// \brief Constructor
+  IOpenbsmConsumer() = default;
+
+  /// \brief Destructor
+  virtual ~IOpenbsmConsumer() = default;
+
+  /// \brief Returns a list of processed events
+  /// \param event_list Where the event list is stored
+  /// \return A Status object
+  virtual Status getEvents(EventList &event_list) = 0;
+
+  IOpenbsmConsumer(const IOpenbsmConsumer &other) = delete;
+
+  IOpenbsmConsumer &operator=(const IOpenbsmConsumer &other) = delete;
+};
+} // namespace zeek

--- a/components/zeekopenbsm/include/zeek/iopenbsmconsumer.h
+++ b/components/zeekopenbsm/include/zeek/iopenbsmconsumer.h
@@ -7,6 +7,7 @@
 
 #include <zeek/izeekconfiguration.h>
 #include <zeek/izeeklogger.h>
+#include <zeek/status.h>
 
 namespace zeek {
 /// \brief OpenBSM consumer (interface)

--- a/components/zeekopenbsm/src/openbsm_utils.cpp
+++ b/components/zeekopenbsm/src/openbsm_utils.cpp
@@ -1,0 +1,28 @@
+#include "openbsm_utils.h"
+
+namespace zeek {
+
+std::string getIpFromToken(const tokenstr_t &tok) {
+  char ip_str[INET6_ADDRSTRLEN] = {0};
+  if (tok.tt.sockinet_ex32.family == 2) {
+    struct in_addr ipv4 {};
+    ipv4.s_addr = static_cast<in_addr_t>(*tok.tt.sockinet_ex32.addr);
+    return std::string(inet_ntop(AF_INET, &ipv4, ip_str, INET6_ADDRSTRLEN));
+  } else {
+    struct in6_addr ipv6 {};
+    memcpy(&ipv6, tok.tt.sockinet_ex32.addr, sizeof(ipv6));
+    return std::string(inet_ntop(AF_INET6, &ipv6, ip_str, INET6_ADDRSTRLEN));
+  }
+}
+
+std::string getPathFromPid(int pid) {
+  char pathbuf[PROC_PIDPATHINFO_MAXSIZE] = {0};
+
+  int ret = proc_pidpath(pid, pathbuf, sizeof(pathbuf));
+  if (ret > 0) {
+    return std::string(pathbuf);
+  } else {
+    return "";
+  }
+}
+} // namespace zeek

--- a/components/zeekopenbsm/src/openbsm_utils.cpp
+++ b/components/zeekopenbsm/src/openbsm_utils.cpp
@@ -7,12 +7,12 @@ Status getIpFromToken(const au_socketinet_ex32_t &sock, std::string &ip_addr) {
   if (sock.family == 2) {
     struct in_addr ipv4 {};
     ipv4.s_addr = static_cast<in_addr_t>(*sock.addr);
-    ip_addr = std::string(inet_ntop(AF_INET, &ipv4, ip_str, INET6_ADDRSTRLEN));
+    ip_addr = inet_ntop(AF_INET, &ipv4, ip_str, INET6_ADDRSTRLEN);
     return Status::success();
   } else if (sock.family == 26) {
     struct in6_addr ipv6 {};
     memcpy(&ipv6, sock.addr, sizeof(ipv6));
-    ip_addr = std::string(inet_ntop(AF_INET6, &ipv6, ip_str, INET6_ADDRSTRLEN));
+    ip_addr = inet_ntop(AF_INET6, &ipv6, ip_str, INET6_ADDRSTRLEN);
     return Status::success();
   }
   return Status::failure("Cannot parse IP address from given token due to "
@@ -24,7 +24,7 @@ Status getPathFromPid(int pid, std::string &path) {
 
   int ret = proc_pidpath(pid, pathbuf, sizeof(pathbuf));
   if (ret > 0) {
-    path = std::string(pathbuf);
+    path = pathbuf;
     return Status::success();
   }
   return Status::failure("Cannot get path from pid: " +

--- a/components/zeekopenbsm/src/openbsm_utils.h
+++ b/components/zeekopenbsm/src/openbsm_utils.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <arpa/inet.h>
+#include <bsm/audit_kevents.h>
+#include <bsm/libbsm.h>
+#include <libproc.h>
+#include <string>
+
+namespace zeek {
+/// \brief Extract ip address from openbsm audit token
+/// \param tok openbsm audit token
+/// \return output ip address string
+std::string getIpFromToken(const tokenstr_t &tok);
+
+/// \brief Get process path from given pid
+/// \param pid process pid
+/// \return process path string
+std::string getPathFromPid(int pid);
+} // namespace zeek

--- a/components/zeekopenbsm/src/openbsm_utils.h
+++ b/components/zeekopenbsm/src/openbsm_utils.h
@@ -3,17 +3,19 @@
 #include <arpa/inet.h>
 #include <bsm/audit_kevents.h>
 #include <bsm/libbsm.h>
+#include <errno.h>
 #include <libproc.h>
 #include <string>
+#include <zeek/status.h>
 
 namespace zeek {
 /// \brief Extract ip address from openbsm audit token
 /// \param tok openbsm audit token
 /// \return output ip address string
-std::string getIpFromToken(const tokenstr_t &tok);
+Status getIpFromToken(const au_socketinet_ex32_t &sock, std::string &ip_addr);
 
 /// \brief Get process path from given pid
 /// \param pid process pid
 /// \return process path string
-std::string getPathFromPid(int pid);
+Status getPathFromPid(int pid, std::string &path);
 } // namespace zeek

--- a/components/zeekopenbsm/src/openbsmconsumer.cpp
+++ b/components/zeekopenbsm/src/openbsmconsumer.cpp
@@ -1,0 +1,363 @@
+#include "openbsmconsumer.h"
+#include "openbsm_utils.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <ctime>
+#include <future>
+#include <iomanip>
+#include <thread>
+
+namespace zeek {
+
+namespace {
+#define AUDIT_PIPE_PATH "/dev/auditpipe"
+} // namespace
+
+struct OpenbsmConsumer::PrivateData final {
+  PrivateData(IZeekLogger &logger_, IZeekConfiguration &configuration_)
+      : logger(logger_), configuration(configuration_) {}
+
+  IZeekLogger &logger;
+  IZeekConfiguration &configuration;
+
+  EventList event_list;
+  std::mutex event_list_mutex;
+  std::condition_variable event_list_cv;
+
+  std::atomic_bool terminate_producer{false};
+};
+
+OpenbsmConsumer::OpenbsmConsumer(IZeekLogger &logger,
+                                 IZeekConfiguration &configuration)
+    : d(new PrivateData(logger, configuration)) {
+
+  // start fetching events from pipe in a separate thread
+  std::thread{&OpenbsmConsumer::fetchEventsFromPipe, this}.detach();
+}
+
+OpenbsmConsumer::~OpenbsmConsumer() {
+  d->terminate_producer = true;
+  if (audit_pipe != nullptr) {
+    fclose(audit_pipe);
+    audit_pipe = nullptr;
+  }
+  d->event_list_cv.notify_all();
+}
+
+Status OpenbsmConsumer::getEvents(EventList &event_list) {
+  event_list = {};
+
+  {
+    std::unique_lock<std::mutex> lock(d->event_list_mutex);
+
+    if (d->event_list_cv.wait_for(lock, std::chrono::seconds(1U)) ==
+        std::cv_status::no_timeout) {
+      event_list = std::move(d->event_list);
+      d->event_list = {};
+    }
+  }
+
+  return Status::success();
+}
+
+void OpenbsmConsumer::extractHeader(IOpenbsmConsumer::Event &event,
+                                    tokenstr_t tok) {
+  switch (tok.id) {
+  case AUT_HEADER32:
+    event.header.timestamp = tok.tt.hdr32.s;
+    if (tok.tt.hdr32.e_type == AUE_CONNECT) {
+      event.type = Event::Type::Connect;
+    } else if (tok.tt.hdr32.e_type == AUE_BIND) {
+      event.type = Event::Type::Bind;
+    }
+    break;
+  case AUT_HEADER64:
+    event.header.timestamp = tok.tt.hdr64.s;
+    if (tok.tt.hdr64.e_type == AUE_CONNECT) {
+      event.type = Event::Type::Connect;
+    } else if (tok.tt.hdr64.e_type == AUE_BIND) {
+      event.type = Event::Type::Bind;
+    }
+    break;
+  case AUT_HEADER32_EX:
+    event.header.timestamp = tok.tt.hdr32_ex.s;
+    if (tok.tt.hdr32_ex.e_type == AUE_CONNECT) {
+      event.type = Event::Type::Connect;
+    } else if (tok.tt.hdr32_ex.e_type == AUE_BIND) {
+      event.type = Event::Type::Bind;
+    }
+    break;
+  case AUT_HEADER64_EX:
+    event.header.timestamp = tok.tt.hdr64_ex.s;
+    if (tok.tt.hdr64_ex.e_type == AUE_CONNECT) {
+      event.type = Event::Type::Connect;
+    } else if (tok.tt.hdr64_ex.e_type == AUE_BIND) {
+      event.type = Event::Type::Bind;
+    }
+    break;
+  }
+}
+
+void OpenbsmConsumer::extractSubject(IOpenbsmConsumer::Event &event,
+                                     tokenstr_t tok) {
+
+  switch (tok.id) {
+  case AUT_SUBJECT32: {
+    uint32_t pid = tok.tt.subj32.pid;
+    event.header.process_id = pid;
+    event.header.path = getPathFromPid(pid);
+    event.header.user_id = tok.tt.subj32.euid;
+    event.header.group_id = tok.tt.subj32.egid;
+    break;
+  }
+  case AUT_SUBJECT64: {
+    uint32_t pid = tok.tt.subj64.pid;
+    event.header.process_id = pid;
+    event.header.path = getPathFromPid(pid);
+    event.header.user_id = tok.tt.subj64.euid;
+    event.header.group_id = tok.tt.subj64.egid;
+    break;
+  }
+  case AUT_SUBJECT32_EX: {
+    uint32_t pid = tok.tt.subj32_ex.pid;
+    event.header.process_id = pid;
+    event.header.path = getPathFromPid(pid);
+    event.header.user_id = tok.tt.subj32_ex.euid;
+    event.header.group_id = tok.tt.subj32_ex.egid;
+    break;
+  }
+  case AUT_SUBJECT64_EX: {
+    uint32_t pid = tok.tt.subj64_ex.pid;
+    event.header.process_id = pid;
+    event.header.path = getPathFromPid(pid);
+    event.header.user_id = tok.tt.subj64_ex.euid;
+    event.header.group_id = tok.tt.subj64_ex.egid;
+    break;
+  }
+  }
+}
+
+void OpenbsmConsumer::extractReturn(IOpenbsmConsumer::Event &event,
+                                    tokenstr_t tok) {
+
+  switch (tok.id) {
+  case AUT_RETURN32: {
+    int error = 0;
+    if (au_bsm_to_errno(tok.tt.ret32.status, &error) == 0) {
+      if (error == 0) {
+        event.header.success = 1;
+      } else {
+        event.header.success = 0;
+      }
+    } else
+      event.header.success = 0;
+    break;
+  }
+  case AUT_RETURN64: {
+    int error = 0;
+    if (au_bsm_to_errno(tok.tt.ret64.err, &error) == 0) {
+      if (error == 0) {
+        event.header.success = 1;
+      } else {
+        event.header.success = 0;
+      }
+    } else
+      event.header.success = 0;
+    break;
+  }
+  }
+}
+void OpenbsmConsumer::extractSocketInet(IOpenbsmConsumer::Event &event,
+                                        tokenstr_t tok) {
+
+  switch (tok.id) {
+  case AUT_SOCKINET32: {
+    if (event.type == Event::Type::Bind) {
+      event.header.remote_address = "0.0.0.0";
+      event.header.remote_port = 0;
+      event.header.local_address = getIpFromToken(tok);
+      event.header.local_port = ntohs(tok.tt.sockinet_ex32.port);
+    } else {
+      event.header.remote_address = getIpFromToken(tok);
+      event.header.remote_port = ntohs(tok.tt.sockinet_ex32.port);
+      event.header.local_address = "0.0.0.0";
+      event.header.local_port = 0;
+    }
+    if (tok.tt.sockinet_ex32.family == 2) {
+      event.header.family = 2;
+    } else if (tok.tt.sockinet_ex32.family == 26) {
+      event.header.family = 10;
+    } else {
+      event.header.family = 0;
+    }
+
+    break;
+  }
+  case AUT_SOCKINET128: {
+    if (event.type == Event::Type::Bind) {
+      event.header.remote_address = "0.0.0.0";
+      event.header.remote_port = 0;
+      event.header.local_address = getIpFromToken(tok);
+      event.header.local_port =
+          static_cast<std::int64_t>(ntohs(tok.tt.sockinet_ex32.port));
+    } else {
+      event.header.remote_address = getIpFromToken(tok);
+      event.header.remote_port =
+          static_cast<std::int64_t>(ntohs(tok.tt.sockinet_ex32.port));
+      event.header.local_address = "0.0.0.0";
+      event.header.local_port = 0;
+    }
+    if (tok.tt.sockinet_ex32.family == 2) {
+      event.header.family = 2;
+    } else if (tok.tt.sockinet_ex32.family == 26) {
+      event.header.family = 10;
+    } else {
+      event.header.family = 0;
+    }
+    break;
+  }
+  }
+}
+
+Status
+OpenbsmConsumer::populateSocketEvent(Event &event,
+                                     const std::vector<tokenstr_t> &tokens) {
+
+  for (const auto &tok : tokens) {
+    if (tok.id == AUT_SOCKUNIX) {
+      // we filter unix sockets out
+      continue;
+    }
+    switch (tok.id) {
+    case AUT_HEADER32:
+    case AUT_HEADER64:
+    case AUT_HEADER32_EX:
+    case AUT_HEADER64_EX:
+      extractHeader(event, tok);
+      break;
+    case AUT_SUBJECT32:
+    case AUT_SUBJECT64:
+    case AUT_SUBJECT32_EX:
+    case AUT_SUBJECT64_EX:
+      extractSubject(event, tok);
+      break;
+    case AUT_RETURN32:
+    case AUT_RETURN64:
+      extractReturn(event, tok);
+      break;
+    case AUT_SOCKINET32:
+    case AUT_SOCKINET128:
+      extractSocketInet(event, tok);
+      break;
+    }
+  } // for loop
+
+  return Status::success();
+}
+
+Status OpenbsmConsumer::parseMessage() {
+
+  Status status;
+  Event event;
+
+  u_char *buffer = nullptr;
+
+  int reclen = au_read_rec(audit_pipe, &buffer);
+
+  if (reclen <= 0) {
+    return Status::failure("Could not openbsm fetch message");
+  }
+
+  tokenstr_t tok;
+  std::vector<tokenstr_t> tokens{};
+  tokens.reserve(12);
+
+  auto event_id = 0;
+  auto bytesread = 0;
+  while (bytesread < reclen) {
+    if (au_fetch_tok(&tok, buffer + bytesread, reclen - bytesread) == -1) {
+      break;
+    }
+    switch (tok.id) {
+    case AUT_HEADER32:
+      event_id = tok.tt.hdr32.e_type;
+      break;
+    case AUT_HEADER32_EX:
+      event_id = tok.tt.hdr32_ex.e_type;
+      break;
+    case AUT_HEADER64:
+      event_id = tok.tt.hdr64.e_type;
+      break;
+    case AUT_HEADER64_EX:
+      event_id = tok.tt.hdr64_ex.e_type;
+      break;
+    }
+    tokens.push_back(tok);
+    bytesread += tok.len;
+  }
+  if (event_filter_list.find(event_id) == event_filter_list.end()) {
+    // Return early for unused event IDs.
+    return Status::success();
+  }
+
+  status = populateSocketEvent(event, tokens);
+
+  if (!status.succeeded()) {
+    d->logger.logMessage(IZeekLogger::Severity::Error, status.message());
+
+  } else {
+    std::lock_guard<std::mutex> lock(d->event_list_mutex);
+    d->event_list.push_back(std::move(event));
+    d->event_list_cv.notify_all();
+  }
+  return status;
+}
+
+Status OpenbsmConsumer::fetchEventsFromPipe() {
+
+  audit_pipe = fopen(AUDIT_PIPE_PATH, "r");
+  if (audit_pipe == nullptr) {
+    throw Status::failure("The auditpipe couldn't be opened.");
+  }
+  event_filter_list.insert(AUE_CONNECT);
+  event_filter_list.insert(AUE_BIND);
+  fd_set fdset;
+  struct timeval timeout {};
+  timeout.tv_sec = 0;
+  timeout.tv_usec = 200000;
+
+  while (!d->terminate_producer) {
+    FD_ZERO(&fdset);
+    FD_SET(fileno(audit_pipe), &fdset);
+
+    int rc = select(FD_SETSIZE, &fdset, nullptr, nullptr, &timeout);
+
+    if (rc == 0) {
+      continue;
+    }
+    if (rc < 0) {
+      if (errno != EINTR) {
+        return Status::failure("Auditpipe cannot be read");
+      }
+      continue;
+    }
+    parseMessage();
+  }
+  return Status::success();
+}
+
+Status IOpenbsmConsumer::create(Ref &obj, IZeekLogger &logger,
+                                IZeekConfiguration &configuration) {
+  try {
+    obj.reset(new OpenbsmConsumer(logger, configuration));
+    return Status::success();
+
+  } catch (const std::bad_alloc &) {
+    return Status::failure("Memory allocation failure");
+
+  } catch (const Status &status) {
+    return status;
+  }
+}
+} // namespace zeek

--- a/components/zeekopenbsm/src/openbsmconsumer.cpp
+++ b/components/zeekopenbsm/src/openbsmconsumer.cpp
@@ -293,7 +293,7 @@ void OpenbsmConsumer::parseRecordIntoTokens() {
 
   if (subscribed_event_ids.find(event_id.value()) ==
       subscribed_event_ids.end()) {
-    // we will not store current record in the event_list
+    // Skip events not subscribed to.
     return;
   }
 

--- a/components/zeekopenbsm/src/openbsmconsumer.h
+++ b/components/zeekopenbsm/src/openbsmconsumer.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <bsm/libbsm.h>
+#include <set>
+#include <vector>
+#include <zeek/iopenbsmconsumer.h>
+
+namespace zeek {
+class OpenbsmConsumer final : public IOpenbsmConsumer {
+public:
+  /// \brief Destructor
+  ~OpenbsmConsumer() override;
+
+  /// \brief Returns a list of processed events
+  /// \param event_list Where the event list is stored
+  /// \return A Status object
+  Status getEvents(EventList &event_list) override;
+
+private:
+  struct PrivateData;
+  std::unique_ptr<PrivateData> d;
+  // audit pipe handler
+  FILE *audit_pipe{nullptr};
+
+  /// list of subscribed events
+  std::set<size_t> event_filter_list;
+
+  /// \brief Constructor
+  OpenbsmConsumer(IZeekLogger &logger, IZeekConfiguration &configuration);
+
+  /// \brief extract header from openbsm token and populate event
+  static void extractHeader(Event &event, tokenstr_t tok);
+  /// \brief extract subject from openbsm token and populate event
+  static void extractSubject(Event &event, tokenstr_t tok);
+  /// \brief extract return from openbsm token and populate event
+  static void extractReturn(Event &event, tokenstr_t tok);
+  /// \brief extract socket-inet from openbsm token and populate event
+  static void extractSocketInet(Event &event, tokenstr_t tok);
+
+public:
+  friend class IOpenbsmConsumer;
+
+  Status fetchEventsFromPipe();
+  static Status populateSocketEvent(Event &event,
+                                    const std::vector<tokenstr_t> &tokens);
+  Status parseMessage();
+};
+} // namespace zeek

--- a/components/zeekopenbsm/src/openbsmconsumer.h
+++ b/components/zeekopenbsm/src/openbsmconsumer.h
@@ -2,8 +2,10 @@
 
 #include <bsm/libbsm.h>
 #include <set>
+#include <thread>
 #include <vector>
 #include <zeek/iopenbsmconsumer.h>
+#include <zeek/status.h>
 
 namespace zeek {
 class OpenbsmConsumer final : public IOpenbsmConsumer {
@@ -23,7 +25,10 @@ private:
   FILE *audit_pipe{nullptr};
 
   /// list of subscribed events
-  std::set<size_t> event_filter_list;
+  std::set<size_t> subscribed_event_ids;
+
+  /// producer thread object
+  std::thread producer_thread;
 
   /// \brief Constructor
   OpenbsmConsumer(IZeekLogger &logger, IZeekConfiguration &configuration);
@@ -40,9 +45,9 @@ private:
 public:
   friend class IOpenbsmConsumer;
 
-  void fetchEventsFromPipe();
-  static Status populateSocketEvent(Event &event,
-                                    const std::vector<tokenstr_t> &tokens);
-  void parseMessage();
+  void fetchRecordsFromAuditPipe();
+  static Status populateEventFromTokens(Event &event,
+                                        const std::vector<tokenstr_t> &tokens);
+  void parseRecordIntoTokens();
 };
 } // namespace zeek

--- a/components/zeekopenbsm/src/openbsmconsumer.h
+++ b/components/zeekopenbsm/src/openbsmconsumer.h
@@ -19,7 +19,7 @@ public:
 private:
   struct PrivateData;
   std::unique_ptr<PrivateData> d;
-  // audit pipe handler
+  /// audit pipe handle
   FILE *audit_pipe{nullptr};
 
   /// list of subscribed events
@@ -29,20 +29,20 @@ private:
   OpenbsmConsumer(IZeekLogger &logger, IZeekConfiguration &configuration);
 
   /// \brief extract header from openbsm token and populate event
-  static void extractHeader(Event &event, tokenstr_t tok);
+  static Status extractHeader(Event &event, tokenstr_t tok);
   /// \brief extract subject from openbsm token and populate event
-  static void extractSubject(Event &event, tokenstr_t tok);
+  static Status extractSubject(Event &event, tokenstr_t tok);
   /// \brief extract return from openbsm token and populate event
-  static void extractReturn(Event &event, tokenstr_t tok);
+  static Status extractReturn(Event &event, tokenstr_t tok);
   /// \brief extract socket-inet from openbsm token and populate event
-  static void extractSocketInet(Event &event, tokenstr_t tok);
+  static Status extractSocketInet(Event &event, tokenstr_t tok);
 
 public:
   friend class IOpenbsmConsumer;
 
-  Status fetchEventsFromPipe();
+  void fetchEventsFromPipe();
   static Status populateSocketEvent(Event &event,
                                     const std::vector<tokenstr_t> &tokens);
-  Status parseMessage();
+  void parseMessage();
 };
 } // namespace zeek

--- a/components/zeekopenbsm/tests/main.cpp
+++ b/components/zeekopenbsm/tests/main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/components/zeekopenbsm/tests/openbsmconsumer.cpp
+++ b/components/zeekopenbsm/tests/openbsmconsumer.cpp
@@ -37,7 +37,7 @@ TEST_CASE(
   tokens.push_back(tok_return);
 
   IOpenbsmConsumer::Event event;
-  auto status = OpenbsmConsumer::populateSocketEvent(event, tokens);
+  auto status = OpenbsmConsumer::populateEventFromTokens(event, tokens);
 
   REQUIRE(status.succeeded());
 
@@ -84,7 +84,7 @@ TEST_CASE("Populating IOpenbsmconsumer::Event given OpenBSM token for Connect "
   tokens.push_back(tok_return);
 
   IOpenbsmConsumer::Event event;
-  auto status = OpenbsmConsumer::populateSocketEvent(event, tokens);
+  auto status = OpenbsmConsumer::populateEventFromTokens(event, tokens);
 
   REQUIRE(status.succeeded());
 
@@ -132,7 +132,7 @@ TEST_CASE(
   tokens.push_back(tok_return);
 
   IOpenbsmConsumer::Event event;
-  auto status = OpenbsmConsumer::populateSocketEvent(event, tokens);
+  auto status = OpenbsmConsumer::populateEventFromTokens(event, tokens);
 
   REQUIRE(status.succeeded());
 
@@ -179,7 +179,7 @@ TEST_CASE("Populating IOpenbsmconsumer::Event given OpenBSM token for Bind "
   tokens.push_back(tok_return);
 
   IOpenbsmConsumer::Event event;
-  auto status = OpenbsmConsumer::populateSocketEvent(event, tokens);
+  auto status = OpenbsmConsumer::populateEventFromTokens(event, tokens);
 
   REQUIRE(status.succeeded());
 

--- a/components/zeekopenbsm/tests/openbsmconsumer.cpp
+++ b/components/zeekopenbsm/tests/openbsmconsumer.cpp
@@ -21,7 +21,7 @@ TEST_CASE(
   tok_socketinet.tt.sockinet_ex32.port = 443;
   tok_socketinet.tt.sockinet_ex32.family = 2;
   struct in_addr inaddr {};
-  inet_pton(2, "1.2.3.4", &inaddr);
+  inet_pton(AF_INET, "1.2.3.4", &inaddr);
   memcpy(tok_socketinet.tt.sockinet_ex32.addr, &inaddr, sizeof(inaddr));
 
   tok_subject.id = AUT_SUBJECT32;
@@ -48,10 +48,58 @@ TEST_CASE(
   REQUIRE(event.header.user_id == 2U);
   REQUIRE(event.header.group_id == 3U);
   REQUIRE(event.header.local_port == 0);
-  REQUIRE(event.header.local_address == "0.0.0.0");
+  REQUIRE(event.header.local_address == "");
   REQUIRE(event.header.remote_port == htons(443));
   REQUIRE(event.header.remote_address == "1.2.3.4");
   REQUIRE(event.header.family == 2);
+}
+
+TEST_CASE("Populating IOpenbsmconsumer::Event given OpenBSM token for Connect "
+          "event with IPv6",
+          "[ZeekOpenbsmConsumer]") {
+  std::vector<tokenstr_t> tokens = {};
+  tokenstr_t tok_header, tok_subject, tok_socketinet, tok_return;
+
+  tok_header.id = AUT_HEADER32;
+  tok_header.tt.hdr32.s = 0U;
+  tok_header.tt.hdr32.e_type = AUE_CONNECT;
+
+  tok_socketinet.id = AUT_SOCKINET32;
+  tok_socketinet.tt.sockinet_ex32.port = 443;
+  tok_socketinet.tt.sockinet_ex32.family = 26;
+  struct in6_addr inaddr {};
+  inet_pton(AF_INET6, "dead:beef:7654:3210:fedc:3210:7654:ba98", &inaddr);
+  memcpy(tok_socketinet.tt.sockinet_ex32.addr, &inaddr, sizeof(inaddr));
+
+  tok_subject.id = AUT_SUBJECT32;
+  tok_subject.tt.subj32.pid = 1U;
+  tok_subject.tt.subj32.euid = 2U;
+  tok_subject.tt.subj32.egid = 3U;
+
+  tok_return.id = AUT_RETURN32;
+
+  tokens.push_back(tok_header);
+  tokens.push_back(tok_socketinet);
+  tokens.push_back(tok_subject);
+  tokens.push_back(tok_return);
+
+  IOpenbsmConsumer::Event event;
+  auto status = OpenbsmConsumer::populateSocketEvent(event, tokens);
+
+  REQUIRE(status.succeeded());
+
+  REQUIRE(event.type == IOpenbsmConsumer::Event::Type::Connect);
+  REQUIRE(event.header.timestamp == 0U);
+  REQUIRE(event.header.process_id == 1U);
+  REQUIRE(event.header.path == "/sbin/launchd");
+  REQUIRE(event.header.user_id == 2U);
+  REQUIRE(event.header.group_id == 3U);
+  REQUIRE(event.header.local_port == 0);
+  REQUIRE(event.header.local_address == "");
+  REQUIRE(event.header.remote_port == htons(443));
+  REQUIRE(event.header.remote_address ==
+          "dead:beef:7654:3210:fedc:3210:7654:ba98");
+  REQUIRE(event.header.family == 10);
 }
 
 TEST_CASE(
@@ -68,7 +116,7 @@ TEST_CASE(
   tok_socketinet.tt.sockinet_ex32.port = 443;
   tok_socketinet.tt.sockinet_ex32.family = 2;
   struct in_addr inaddr {};
-  inet_pton(2, "1.2.3.4", &inaddr);
+  inet_pton(AF_INET, "1.2.3.4", &inaddr);
   memcpy(tok_socketinet.tt.sockinet_ex32.addr, &inaddr, sizeof(inaddr));
 
   tok_subject.id = AUT_SUBJECT32;
@@ -95,9 +143,57 @@ TEST_CASE(
   REQUIRE(event.header.user_id == 2U);
   REQUIRE(event.header.group_id == 3U);
   REQUIRE(event.header.remote_port == 0);
-  REQUIRE(event.header.remote_address == "0.0.0.0");
+  REQUIRE(event.header.remote_address == "");
   REQUIRE(event.header.local_port == htons(443));
   REQUIRE(event.header.local_address == "1.2.3.4");
   REQUIRE(event.header.family == 2);
+}
+
+TEST_CASE("Populating IOpenbsmconsumer::Event given OpenBSM token for Bind "
+          "event with IPv6",
+          "[ZeekOpenbsmConsumer]") {
+  std::vector<tokenstr_t> tokens = {};
+  tokenstr_t tok_header, tok_subject, tok_socketinet, tok_return;
+
+  tok_header.id = AUT_HEADER32;
+  tok_header.tt.hdr32.s = 0U;
+  tok_header.tt.hdr32.e_type = AUE_BIND;
+
+  tok_socketinet.id = AUT_SOCKINET32;
+  tok_socketinet.tt.sockinet_ex32.port = 443;
+  tok_socketinet.tt.sockinet_ex32.family = 26;
+  struct in6_addr inaddr {};
+  inet_pton(AF_INET6, "dead:beef:7654:3210:fedc:3210:7654:ba98", &inaddr);
+  memcpy(tok_socketinet.tt.sockinet_ex32.addr, &inaddr, sizeof(inaddr));
+
+  tok_subject.id = AUT_SUBJECT32;
+  tok_subject.tt.subj32.pid = 1U;
+  tok_subject.tt.subj32.euid = 2U;
+  tok_subject.tt.subj32.egid = 3U;
+
+  tok_return.id = AUT_RETURN32;
+
+  tokens.push_back(tok_header);
+  tokens.push_back(tok_socketinet);
+  tokens.push_back(tok_subject);
+  tokens.push_back(tok_return);
+
+  IOpenbsmConsumer::Event event;
+  auto status = OpenbsmConsumer::populateSocketEvent(event, tokens);
+
+  REQUIRE(status.succeeded());
+
+  REQUIRE(event.type == IOpenbsmConsumer::Event::Type::Bind);
+  REQUIRE(event.header.timestamp == 0U);
+  REQUIRE(event.header.process_id == 1U);
+  REQUIRE(event.header.path == "/sbin/launchd");
+  REQUIRE(event.header.user_id == 2U);
+  REQUIRE(event.header.group_id == 3U);
+  REQUIRE(event.header.remote_port == 0);
+  REQUIRE(event.header.remote_address == "");
+  REQUIRE(event.header.local_port == htons(443));
+  REQUIRE(event.header.local_address ==
+          "dead:beef:7654:3210:fedc:3210:7654:ba98");
+  REQUIRE(event.header.family == 10);
 }
 } // namespace zeek

--- a/components/zeekopenbsm/tests/openbsmconsumer.cpp
+++ b/components/zeekopenbsm/tests/openbsmconsumer.cpp
@@ -1,0 +1,103 @@
+#include "openbsmconsumer.h"
+
+#include <arpa/inet.h>
+#include <bsm/audit_kevents.h>
+#include <bsm/libbsm.h>
+#include <catch2/catch.hpp>
+#include <string>
+
+namespace zeek {
+TEST_CASE(
+    "Populating IOpenbsmconsumer::Event given OpenBSM token for Connect event",
+    "[ZeekOpenbsmConsumer]") {
+  std::vector<tokenstr_t> tokens = {};
+  tokenstr_t tok_header, tok_subject, tok_socketinet, tok_return;
+
+  tok_header.id = AUT_HEADER32;
+  tok_header.tt.hdr32.s = 0U;
+  tok_header.tt.hdr32.e_type = AUE_CONNECT;
+
+  tok_socketinet.id = AUT_SOCKINET32;
+  tok_socketinet.tt.sockinet_ex32.port = 443;
+  tok_socketinet.tt.sockinet_ex32.family = 2;
+  struct in_addr inaddr {};
+  inet_pton(2, "1.2.3.4", &inaddr);
+  memcpy(tok_socketinet.tt.sockinet_ex32.addr, &inaddr, sizeof(inaddr));
+
+  tok_subject.id = AUT_SUBJECT32;
+  tok_subject.tt.subj32.pid = 1U;
+  tok_subject.tt.subj32.euid = 2U;
+  tok_subject.tt.subj32.egid = 3U;
+
+  tok_return.id = AUT_RETURN32;
+
+  tokens.push_back(tok_header);
+  tokens.push_back(tok_socketinet);
+  tokens.push_back(tok_subject);
+  tokens.push_back(tok_return);
+
+  IOpenbsmConsumer::Event event;
+  auto status = OpenbsmConsumer::populateSocketEvent(event, tokens);
+
+  REQUIRE(status.succeeded());
+
+  REQUIRE(event.type == IOpenbsmConsumer::Event::Type::Connect);
+  REQUIRE(event.header.timestamp == 0U);
+  REQUIRE(event.header.process_id == 1U);
+  REQUIRE(event.header.path == "/sbin/launchd");
+  REQUIRE(event.header.user_id == 2U);
+  REQUIRE(event.header.group_id == 3U);
+  REQUIRE(event.header.local_port == 0);
+  REQUIRE(event.header.local_address == "0.0.0.0");
+  REQUIRE(event.header.remote_port == htons(443));
+  REQUIRE(event.header.remote_address == "1.2.3.4");
+  REQUIRE(event.header.family == 2);
+}
+
+TEST_CASE(
+    "Populating IOpenbsmconsumer::Event given OpenBSM token for Bind event",
+    "[ZeekOpenbsmConsumer]") {
+  std::vector<tokenstr_t> tokens = {};
+  tokenstr_t tok_header, tok_subject, tok_socketinet, tok_return;
+
+  tok_header.id = AUT_HEADER32;
+  tok_header.tt.hdr32.s = 0U;
+  tok_header.tt.hdr32.e_type = AUE_BIND;
+
+  tok_socketinet.id = AUT_SOCKINET32;
+  tok_socketinet.tt.sockinet_ex32.port = 443;
+  tok_socketinet.tt.sockinet_ex32.family = 2;
+  struct in_addr inaddr {};
+  inet_pton(2, "1.2.3.4", &inaddr);
+  memcpy(tok_socketinet.tt.sockinet_ex32.addr, &inaddr, sizeof(inaddr));
+
+  tok_subject.id = AUT_SUBJECT32;
+  tok_subject.tt.subj32.pid = 1U;
+  tok_subject.tt.subj32.euid = 2U;
+  tok_subject.tt.subj32.egid = 3U;
+
+  tok_return.id = AUT_RETURN32;
+
+  tokens.push_back(tok_header);
+  tokens.push_back(tok_socketinet);
+  tokens.push_back(tok_subject);
+  tokens.push_back(tok_return);
+
+  IOpenbsmConsumer::Event event;
+  auto status = OpenbsmConsumer::populateSocketEvent(event, tokens);
+
+  REQUIRE(status.succeeded());
+
+  REQUIRE(event.type == IOpenbsmConsumer::Event::Type::Bind);
+  REQUIRE(event.header.timestamp == 0U);
+  REQUIRE(event.header.process_id == 1U);
+  REQUIRE(event.header.path == "/sbin/launchd");
+  REQUIRE(event.header.user_id == 2U);
+  REQUIRE(event.header.group_id == 3U);
+  REQUIRE(event.header.remote_port == 0);
+  REQUIRE(event.header.remote_address == "0.0.0.0");
+  REQUIRE(event.header.local_port == htons(443));
+  REQUIRE(event.header.local_address == "1.2.3.4");
+  REQUIRE(event.header.family == 2);
+}
+} // namespace zeek

--- a/libraries/broker-legacy/CMakeLists.txt
+++ b/libraries/broker-legacy/CMakeLists.txt
@@ -318,6 +318,7 @@ function(generateBroker)
     PUBLIC
       zeek_agent_cxx_settings
       thirdparty_actorframework
+      thirdparty_caf_openssl
       thirdparty_sqlite
 
     PRIVATE

--- a/libraries/openssl/CMakeLists.txt
+++ b/libraries/openssl/CMakeLists.txt
@@ -26,14 +26,14 @@ function(zeekAgentLibrariesOpenSSL)
         "https://www.openssl.org/source/openssl-${openssl_version}.tar.gz"
         "https://www.openssl.org/source/old/${openssl_truncated_version}/openssl-${openssl_version}.tar.gz"
 
-      CONFIGURE_COMMAND 
+      CONFIGURE_COMMAND
         "${CMAKE_COMMAND}" -E env CC="${CMAKE_C_COMPILER}" AR="${CMAKE_AR}"
         perl ./Configure linux-x86_64 no-ssl2 no-ssl3 no-asm no-shared no-weak-ssl-ciphers
               zlib-dynamic enable-cms "--with-zlib-include=${zlib_include_path}"
               "--with-zlib-lib=$<TARGET_FILE:thirdparty_zlib>" "--prefix=/"
               "--openssldir=/etc/openssl" -fPIC --sysroot=${CMAKE_SYSROOT}
               -l:libunwind.a -lpthread
-      
+
       BUILD_COMMAND
         make depend &&
         make -j 2
@@ -65,7 +65,7 @@ function(zeekAgentLibrariesOpenSSL)
         "https://www.openssl.org/source/openssl-${openssl_version}.tar.gz"
         "https://www.openssl.org/source/old/${openssl_truncated_version}/openssl-${openssl_version}.tar.gz"
 
-      CONFIGURE_COMMAND 
+      CONFIGURE_COMMAND
         "${CMAKE_COMMAND}" -E env CC="${CMAKE_C_COMPILER}" AR="${CMAKE_AR}"
         perl ./Configure darwin64-x86_64-cc no-ssl2 no-ssl3 no-asm no-shared no-weak-ssl-ciphers
               zlib-dynamic enable-cms "--with-zlib-include=${zlib_include_path}"
@@ -105,7 +105,7 @@ function(zeekAgentLibrariesOpenSSL)
         "https://www.openssl.org/source/openssl-${openssl_version}.tar.gz"
         "https://www.openssl.org/source/old/${openssl_truncated_version}/openssl-${openssl_version}.tar.gz"
 
-      CONFIGURE_COMMAND 
+      CONFIGURE_COMMAND
         "${CMAKE_COMMAND}" -E env "${PERL_EXECUTABLE}" Configure VC-WIN64A no-ssl2 no-ssl3 no-asm no-shared
                                                        no-weak-ssl-ciphers zlib-dynamic enable-cms
                                                        "--with-zlib-include=${zlib_include_path}"
@@ -166,8 +166,8 @@ function(zeekAgentLibrariesOpenSSL)
 
   add_library(thirdparty_openssl INTERFACE)
   target_link_libraries(thirdparty_openssl INTERFACE
-    thirdparty_openssl_libcrypto
     thirdparty_openssl_libssl
+    thirdparty_openssl_libcrypto
   )
 endfunction()
 

--- a/src/zeekagent.cpp
+++ b/src/zeekagent.cpp
@@ -14,6 +14,7 @@
 #include <zeek/audispservicefactory.h>
 #elif defined(ZEEK_AGENT_PLATFORM_MACOS)
 #include <zeek/endpointsecurityservicefactory.h>
+#include <zeek/openbsmservicefactory.h>
 #endif
 
 #include <zeek/ihostinformationtableplugin.h>
@@ -249,6 +250,17 @@ ZeekAgent::initializeServiceManager(IZeekServiceManager::Ref &service_manager) {
         IZeekLogger::Severity::Error,
         "The EndpointSecurity tables could not be initialized: " +
             status.message());
+
+    throw status;
+  }
+
+  status = registerOpenbsmServiceFactory(
+      *service_manager.get(), virtual_database, getConfig(), getLogger());
+
+  if (!status.succeeded()) {
+    getLogger().logMessage(IZeekLogger::Severity::Error,
+                           "The Openbsm table could not be initialized: " +
+                               status.message());
 
     throw status;
   }

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -7,6 +7,7 @@ function(zeekAgentTables)
     add_subdirectory("audisp")
   elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     add_subdirectory("endpointsecurity")
+    add_subdirectory("openbsm")
   endif()
 
   add_subdirectory("host_information")

--- a/tables/audisp/CMakeLists.txt
+++ b/tables/audisp/CMakeLists.txt
@@ -8,6 +8,9 @@ function(zeekAgentTablesAudisp)
     src/socketeventstableplugin.h
     src/socketeventstableplugin.cpp
 
+    src/fileeventstableplugin.h
+    src/fileeventstableplugin.cpp
+
     src/processeventstableplugin.h
     src/processeventstableplugin.cpp
 
@@ -44,6 +47,7 @@ function(zeekAgentTablesAudisp)
 
       tests/processeventstableplugin.cpp
       tests/socketeventstableplugin.cpp
+      tests/fileeventstableplugin.cpp
   )
 endfunction()
 

--- a/tables/audisp/src/fileeventstableplugin.cpp
+++ b/tables/audisp/src/fileeventstableplugin.cpp
@@ -1,0 +1,241 @@
+#include "fileeventstableplugin.h"
+
+#include <chrono>
+#include <filesystem>
+#include <mutex>
+
+namespace zeek {
+struct FileEventsTablePlugin::PrivateData final {
+  PrivateData(IZeekConfiguration &configuration_, IZeekLogger &logger_)
+      : configuration(configuration_), logger(logger_) {}
+
+  IZeekConfiguration &configuration;
+  IZeekLogger &logger;
+
+  RowList row_list;
+  std::mutex row_list_mutex;
+  std::size_t max_queued_row_count{0U};
+};
+
+Status FileEventsTablePlugin::create(Ref &obj,
+                                     IZeekConfiguration &configuration,
+                                     IZeekLogger &logger) {
+  try {
+    auto ptr = new FileEventsTablePlugin(configuration, logger);
+    obj.reset(ptr);
+
+    return Status::success();
+
+  } catch (const std::bad_alloc &) {
+    return Status::failure("Memory allocation failure");
+
+  } catch (const Status &status) {
+    return status;
+  }
+}
+
+FileEventsTablePlugin::~FileEventsTablePlugin() {}
+
+const std::string &FileEventsTablePlugin::name() const {
+  static const std::string kTableName{"file_events"};
+
+  return kTableName;
+}
+
+const FileEventsTablePlugin::Schema &FileEventsTablePlugin::schema() const {
+  static const Schema kTableSchema = {
+      {"syscall", IVirtualTable::ColumnType::String},
+      {"pid", IVirtualTable::ColumnType::Integer},
+      {"ppid", IVirtualTable::ColumnType::Integer},
+      {"uid", IVirtualTable::ColumnType::Integer},
+      {"gid", IVirtualTable::ColumnType::Integer},
+      {"auid", IVirtualTable::ColumnType::Integer},
+      {"euid", IVirtualTable::ColumnType::Integer},
+      {"egid", IVirtualTable::ColumnType::Integer},
+      {"exe", IVirtualTable::ColumnType::String},
+      {"path", IVirtualTable::ColumnType::String},
+      {"inode", IVirtualTable::ColumnType::Integer},
+      {"time", IVirtualTable::ColumnType::Integer}};
+
+  return kTableSchema;
+}
+
+Status FileEventsTablePlugin::generateRowList(RowList &row_list) {
+  std::lock_guard<std::mutex> lock(d->row_list_mutex);
+
+  row_list = std::move(d->row_list);
+  d->row_list = {};
+
+  return Status::success();
+}
+
+Status FileEventsTablePlugin::processEvents(
+    const IAudispConsumer::AuditEventList &event_list) {
+  RowList generated_row_list;
+
+  for (const auto &audit_event : event_list) {
+    Row row;
+
+    auto status = generateRow(row, audit_event);
+    if (!status.succeeded()) {
+      return status;
+    }
+
+    if (!row.empty()) {
+      {
+        std::lock_guard<std::mutex> lock(d->row_list_mutex);
+        d->row_list.push_back(row);
+      }
+    }
+  }
+
+  if (d->row_list.size() > d->max_queued_row_count) {
+
+    std::lock_guard<std::mutex> lock(d->row_list_mutex);
+
+    if (d->row_list.size() > d->max_queued_row_count) {
+      auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
+
+      d->logger.logMessage(IZeekLogger::Severity::Warning,
+                           "file_events: Dropping " +
+                               std::to_string(rows_to_remove) +
+                               " rows (max row count is set to " +
+                               std::to_string(d->max_queued_row_count) + ")");
+
+      d->row_list.erase(d->row_list.begin(),
+                        std::next(d->row_list.begin(), rows_to_remove));
+    }
+  }
+
+  return Status::success();
+}
+
+FileEventsTablePlugin::FileEventsTablePlugin(IZeekConfiguration &configuration,
+                                             IZeekLogger &logger)
+    : d(new PrivateData(configuration, logger)) {
+
+  d->max_queued_row_count = d->configuration.maxQueuedRowCount();
+}
+
+std::string FileEventsTablePlugin::CombinePaths(const std::string &cwd,
+                                                const std::string &path) {
+  std::string full_path;
+
+  // Quotes are only present when path contain space
+  if (path[0] == '"') {
+    full_path = path.substr(1, path.size() - 2);
+  } else {
+    full_path = path;
+  }
+
+  // Use cwd when path is not absolute
+  if (full_path[0] != '/') {
+    std::string normalized_cwd;
+
+    if (cwd[0] == '"') {
+      normalized_cwd = cwd.substr(1, cwd.size() - 2);
+    } else {
+      normalized_cwd = cwd;
+    }
+
+    full_path = std::filesystem::path(normalized_cwd) / full_path;
+  }
+  return full_path;
+}
+
+Status FileEventsTablePlugin::generateRow(
+    Row &row, const IAudispConsumer::AuditEvent &audit_event) {
+  row = {};
+
+  std::string syscall_name;
+  std::string full_path;
+  std::int64_t inode;
+  switch (audit_event.syscall_data.type) {
+  case IAudispConsumer::SyscallRecordData::Type::Open:
+  case IAudispConsumer::SyscallRecordData::Type::OpenAt: {
+    if (!audit_event.cwd_data.has_value()) {
+      return Status::failure("Missing an AUDIT_CWD record from a file event");
+    }
+    if (!audit_event.path_data.has_value()) {
+      return Status::failure("Missing an AUDIT_PATH record from a file event");
+    }
+    if (audit_event.syscall_data.type ==
+        IAudispConsumer::SyscallRecordData::Type::Open)
+      syscall_name = "open";
+    else
+      syscall_name = "openat";
+
+    std::string working_dir_path;
+    std::string file_path;
+    const auto &path_record = audit_event.path_data.value();
+    const auto &cwd_record = audit_event.cwd_data.value();
+
+    if (path_record.size() == 1) {
+      working_dir_path = cwd_record;
+      file_path = path_record.at(0).path;
+      inode = path_record.at(0).inode;
+
+    } else if (path_record.size() == 2) {
+      working_dir_path = path_record.at(0).path;
+      file_path = path_record.at(1).path;
+      inode = path_record.at(1).inode;
+
+    } else if (path_record.size() == 3) {
+      working_dir_path = cwd_record;
+      file_path = path_record.at(0).path;
+      inode = path_record.at(0).inode;
+
+    } else {
+      return Status::failure(
+          "Wrong number of path records for open/openat syscall event");
+    }
+    full_path = CombinePaths(working_dir_path, file_path);
+    break;
+  }
+  case IAudispConsumer::SyscallRecordData::Type::Create: {
+    if (!audit_event.path_data.has_value()) {
+      return Status::failure("Missing an AUDIT_PATH record from a file event");
+    }
+    syscall_name = "create";
+    const auto &path_record = audit_event.path_data.value();
+    if (path_record.size() != 2) {
+      return Status::failure(
+          "Wrong number of path records for create syscall event");
+    }
+    std::string working_dir_path = path_record.at(0).path;
+    std::string file_path = path_record.at(1).path;
+    full_path = CombinePaths(working_dir_path, file_path);
+    inode = path_record.at(1).inode;
+    break;
+  }
+  case IAudispConsumer::SyscallRecordData::Type::Execve:
+  case IAudispConsumer::SyscallRecordData::Type::ExecveAt:
+  case IAudispConsumer::SyscallRecordData::Type::Fork:
+  case IAudispConsumer::SyscallRecordData::Type::VFork:
+  case IAudispConsumer::SyscallRecordData::Type::Clone:
+  case IAudispConsumer::SyscallRecordData::Type::Bind:
+  case IAudispConsumer::SyscallRecordData::Type::Connect:
+    return Status::success();
+  }
+
+  const auto &syscall_data = audit_event.syscall_data;
+
+  row["syscall"] = std::move(syscall_name);
+  row["pid"] = syscall_data.process_id;
+  row["ppid"] = syscall_data.parent_process_id;
+  row["uid"] = syscall_data.uid;
+  row["gid"] = syscall_data.gid;
+  row["auid"] = syscall_data.auid;
+  row["euid"] = syscall_data.euid;
+  row["egid"] = syscall_data.egid;
+  row["exe"] = syscall_data.exe;
+  row["path"] = std::move(full_path);
+  row["inode"] = inode;
+  auto current_timestamp = std::chrono::duration_cast<std::chrono::seconds>(
+      std::chrono::system_clock::now().time_since_epoch());
+
+  row["time"] = static_cast<std::int64_t>(current_timestamp.count());
+
+  return Status::success();
+}
+} // namespace zeek

--- a/tables/audisp/src/fileeventstableplugin.h
+++ b/tables/audisp/src/fileeventstableplugin.h
@@ -1,13 +1,16 @@
 #pragma once
 
+#include <memory>
+#include <string>
 #include <zeek/iaudispconsumer.h>
 #include <zeek/ivirtualtable.h>
 #include <zeek/izeekconfiguration.h>
 #include <zeek/izeeklogger.h>
+#include <zeek/status.h>
 
 namespace zeek {
-/// \brief Provides the process_events table
-class ProcessEventsTablePlugin final : public IVirtualTable {
+/// \brief Provides the file_events table
+class FileEventsTablePlugin final : public IVirtualTable {
   struct PrivateData;
   std::unique_ptr<PrivateData> d;
 
@@ -21,7 +24,7 @@ public:
                        IZeekLogger &logger);
 
   /// \brief Destructor
-  virtual ~ProcessEventsTablePlugin() override;
+  virtual ~FileEventsTablePlugin() override;
 
   /// \return The table name
   virtual const std::string &name() const override;
@@ -51,7 +54,12 @@ protected:
   /// \brief Constructor
   /// \param configuration An initialized configuration object
   /// \param logger An initialized logger object
-  ProcessEventsTablePlugin(IZeekConfiguration &configuration,
-                           IZeekLogger &logger);
+  FileEventsTablePlugin(IZeekConfiguration &configuration, IZeekLogger &logger);
+
+  /// \brief Combines working directory with file path
+  /// \param cwd current directory path
+  /// \param path file path
+  static std::string CombinePaths(const std::string &cwd,
+                                  const std::string &path);
 };
 } // namespace zeek

--- a/tables/audisp/src/socketeventstableplugin.h
+++ b/tables/audisp/src/socketeventstableplugin.h
@@ -40,19 +40,18 @@ public:
   /// \return A Status object
   Status processEvents(const IAudispConsumer::AuditEventList &event_list);
 
-protected:
-  /// \brief Constructor
-  /// \param configuration An initialized configuration object
-  /// \param logger An initialized logger object
-  SocketEventsTablePlugin(IZeekConfiguration &configuration,
-                          IZeekLogger &logger);
-
-public:
   /// \brief Generates a new row from the given Audit event
   /// \param row Where the generated row is stored
   /// \param audit_event The source Audit event
   /// \return A Status object
   static Status generateRow(Row &row,
                             const IAudispConsumer::AuditEvent &audit_event);
+
+protected:
+  /// \brief Constructor
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  SocketEventsTablePlugin(IZeekConfiguration &configuration,
+                          IZeekLogger &logger);
 };
 } // namespace zeek

--- a/tables/audisp/tests/fileeventstableplugin.cpp
+++ b/tables/audisp/tests/fileeventstableplugin.cpp
@@ -1,0 +1,325 @@
+#include "fileeventstableplugin.h"
+#include "utils.h"
+
+#include <catch2/catch.hpp>
+
+namespace zeek {
+SCENARIO("Row generation in the file_events table", "[FileEventsTablePlugin]") {
+
+  GIVEN("a valid create syscall audit event") {
+
+    // clang-format off
+    static const IAudispConsumer::AuditEvent kCreateAuditEvent = {
+        // Syscall record data
+        {
+            IAudispConsumer::SyscallRecordData::Type::Create,
+            0,
+            38031,
+            38030,
+            true,
+            1000,
+            1000,
+            1000,
+            1000,
+            1000,
+            "/home/wajih/a.out",
+            "560a3d760004"
+        },
+
+        // Execve record data
+        {
+        },
+
+        // Path record data
+        {
+            {
+                {
+                    "/home/wajih",
+                    040755,
+                    1000,
+                    1000,
+                    668350
+                },
+
+                {
+                    "file.txt",
+                    0100744,
+                    1000,
+                    1000,
+                    677951
+                }
+            }
+        },
+
+        // Cwd data
+        {
+            "/home/wajih"
+        },
+
+        // Sockaddr data
+        {}
+    };
+    // clang-format on
+
+    WHEN("generating a table row") {
+      IVirtualTable::Row row;
+      auto status = FileEventsTablePlugin::generateRow(row, kCreateAuditEvent);
+
+      REQUIRE(status.succeeded());
+
+      THEN("rows are generated correctly") {
+        static ExpectedValueList kExpectedColumnList = {
+            {"syscall", "create"},
+            {"pid", kCreateAuditEvent.syscall_data.process_id},
+            {"ppid", kCreateAuditEvent.syscall_data.parent_process_id},
+            {"uid", kCreateAuditEvent.syscall_data.uid},
+            {"gid", kCreateAuditEvent.syscall_data.gid},
+            {"auid", kCreateAuditEvent.syscall_data.auid},
+            {"euid", kCreateAuditEvent.syscall_data.euid},
+            {"egid", kCreateAuditEvent.syscall_data.egid},
+            {"exe", "/home/wajih/a.out"},
+            {"path", "/home/wajih/file.txt"},
+            {"inode", static_cast<std::int64_t>(677951)}};
+
+        REQUIRE(row.size() == kExpectedColumnList.size() + 1);
+
+        REQUIRE(row.count("time") != 0U);
+        REQUIRE(row.at("time").has_value());
+
+        validateRow(row, kExpectedColumnList);
+      }
+    }
+  }
+  GIVEN("a valid open syscall audit event") {
+    // clang-format off
+    static const IAudispConsumer::AuditEvent kCreateAuditEvent = {
+        // Syscall record data
+        {
+            IAudispConsumer::SyscallRecordData::Type::Open,
+            0,
+            38031,
+            38030,
+            true,
+            500,
+            500,
+            500,
+            500,
+            500,
+            "/bin/cat",
+            "7fffd19c5592"
+        },
+
+        // Execve record data
+        {
+        },
+
+        // Path record data
+        {
+            {
+                {
+                    "/etc/ssh/sshd_config",
+                    0100600,
+                    0,
+                    0,
+                    409242
+                }
+            }
+        },
+
+        // Cwd data
+        {
+            "/home/wajih"
+        },
+
+        // Sockaddr data
+        {}
+    };
+    // clang-format on
+    WHEN("generating a table row") {
+      IVirtualTable::Row row;
+      auto status = FileEventsTablePlugin::generateRow(row, kCreateAuditEvent);
+
+      REQUIRE(status.succeeded());
+
+      THEN("rows are generated correctly") {
+        static ExpectedValueList kExpectedColumnList = {
+            {"syscall", "open"},
+            {"pid", kCreateAuditEvent.syscall_data.process_id},
+            {"ppid", kCreateAuditEvent.syscall_data.parent_process_id},
+            {"uid", kCreateAuditEvent.syscall_data.uid},
+            {"gid", kCreateAuditEvent.syscall_data.gid},
+            {"auid", kCreateAuditEvent.syscall_data.auid},
+            {"euid", kCreateAuditEvent.syscall_data.euid},
+            {"egid", kCreateAuditEvent.syscall_data.egid},
+            {"exe", "/bin/cat"},
+            {"path", "/etc/ssh/sshd_config"},
+            {"inode", static_cast<std::int64_t>(409242)}};
+
+        REQUIRE(row.size() == kExpectedColumnList.size() + 1);
+
+        REQUIRE(row.count("time") != 0U);
+        REQUIRE(row.at("time").has_value());
+
+        validateRow(row, kExpectedColumnList);
+      }
+    }
+  }
+
+  GIVEN("a valid open syscall audit event with a space in AUDIT_PATH name field") {
+    // clang-format off
+    static const IAudispConsumer::AuditEvent kCreateAuditEvent = {
+        // Syscall record data
+        {
+            IAudispConsumer::SyscallRecordData::Type::Open,
+            0,
+            38031,
+            38030,
+            true,
+            500,
+            500,
+            500,
+            500,
+            500,
+            "/bin/cat",
+            "7fffd19c5592"
+        },
+
+        // Execve record data
+        {
+        },
+
+        // Path record data
+        {
+            {
+                {
+                    "\"/etc/nginx/nginx config\"",
+                    0100600,
+                    0,
+                    0,
+                    409242
+                }
+            }
+        },
+
+        // Cwd data
+        {
+            "/home/wajih"
+        },
+
+        // Sockaddr data
+        {}
+    };
+    // clang-format on
+    WHEN("generating a table row") {
+      IVirtualTable::Row row;
+      auto status = FileEventsTablePlugin::generateRow(row, kCreateAuditEvent);
+
+      REQUIRE(status.succeeded());
+
+      THEN("rows are generated correctly") {
+        static ExpectedValueList kExpectedColumnList = {
+            {"syscall", "open"},
+            {"pid", kCreateAuditEvent.syscall_data.process_id},
+            {"ppid", kCreateAuditEvent.syscall_data.parent_process_id},
+            {"uid", kCreateAuditEvent.syscall_data.uid},
+            {"gid", kCreateAuditEvent.syscall_data.gid},
+            {"auid", kCreateAuditEvent.syscall_data.auid},
+            {"euid", kCreateAuditEvent.syscall_data.euid},
+            {"egid", kCreateAuditEvent.syscall_data.egid},
+            {"exe", "/bin/cat"},
+            {"path", "/etc/nginx/nginx config"},
+            {"inode", static_cast<std::int64_t>(409242)}};
+
+        REQUIRE(row.size() == kExpectedColumnList.size() + 1);
+
+        REQUIRE(row.count("time") != 0U);
+        REQUIRE(row.at("time").has_value());
+
+        validateRow(row, kExpectedColumnList);
+      }
+    }
+  }
+
+  GIVEN("a valid openat syscall audit event") {
+    // clang-format off
+    static const IAudispConsumer::AuditEvent kCreateAuditEvent = {
+        // Syscall record data
+        {
+            IAudispConsumer::SyscallRecordData::Type::OpenAt,
+            0,
+            38031,
+            38030,
+            true,
+            1000,
+            1000,
+            1000,
+            1000,
+            1000,
+            "/home/wajih/a.out",
+            "ffffff9c"
+        },
+
+        // Execve record data
+        {
+        },
+
+        // Path record data
+        {
+            {
+                {
+                    "/home/wajih",
+                    040755,
+                    1000,
+                    1000,
+                    786436
+                },
+                {
+                    "file.txt",
+                    0102430,
+                    1000,
+                    1000,
+                    806807
+                }
+            }
+        },
+
+        // Cwd data
+        {
+            "/home/wajih"
+        },
+
+        // Sockaddr data
+        {}
+    };
+    // clang-format on
+    WHEN("generating a table row") {
+      IVirtualTable::Row row;
+      auto status = FileEventsTablePlugin::generateRow(row, kCreateAuditEvent);
+
+      REQUIRE(status.succeeded());
+
+      THEN("rows are generated correctly") {
+        static ExpectedValueList kExpectedColumnList = {
+            {"syscall", "openat"},
+            {"pid", kCreateAuditEvent.syscall_data.process_id},
+            {"ppid", kCreateAuditEvent.syscall_data.parent_process_id},
+            {"uid", kCreateAuditEvent.syscall_data.uid},
+            {"gid", kCreateAuditEvent.syscall_data.gid},
+            {"auid", kCreateAuditEvent.syscall_data.auid},
+            {"euid", kCreateAuditEvent.syscall_data.euid},
+            {"egid", kCreateAuditEvent.syscall_data.egid},
+            {"exe", "/home/wajih/a.out"},
+            {"path", "/home/wajih/file.txt"},
+            {"inode", static_cast<std::int64_t>(806807)}};
+
+        REQUIRE(row.size() == kExpectedColumnList.size() + 1);
+
+        REQUIRE(row.count("time") != 0U);
+        REQUIRE(row.at("time").has_value());
+
+        validateRow(row, kExpectedColumnList);
+      }
+    }
+  }
+}
+} // namespace zeek

--- a/tables/audisp/tests/processeventstableplugin.cpp
+++ b/tables/audisp/tests/processeventstableplugin.cpp
@@ -22,8 +22,8 @@ SCENARIO("Row generation in the process_events table",
         1000,
         1000,
         1000,
-        "23eb8e0",
-        "\"/usr/bin/bash\""
+        "\"/usr/bin/bash\"",
+        "23eb8e0"
       },
 
       // Execve record data
@@ -44,14 +44,16 @@ SCENARIO("Row generation in the process_events table",
             "/usr/bin/bash",
             0755,
             0,
-            0
+            0,
+           806807
           },
 
           {
             "/lib64/ld-linux-x86-64.so.2",
             0755,
             0,
-            0
+            0,
+           786436,
           }
         }
       },
@@ -74,25 +76,24 @@ SCENARIO("Row generation in the process_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedColumnList = {
-          { "syscall", "execve" },
-          { "pid", kExecveAuditEvent.syscall_data.process_id },
-          { "parent", kExecveAuditEvent.syscall_data.parent_process_id },
-          { "auid", kExecveAuditEvent.syscall_data.auid },
-          { "uid", kExecveAuditEvent.syscall_data.uid },
-          { "euid", kExecveAuditEvent.syscall_data.euid },
-          { "gid", kExecveAuditEvent.syscall_data.gid },
-          { "egid", kExecveAuditEvent.syscall_data.egid },
-          { "owner_uid", static_cast<std::int64_t>(0) },
-          { "owner_gid", static_cast<std::int64_t>(0) },
-          { "cmdline_size", static_cast<std::int64_t>(24) },
-          { "cmdline", "\"-c\" \"echo hello world!\"" },
-          { "path", "/usr/bin/bash" },
-          { "mode", static_cast<std::int64_t>(0755) },
-          { "cwd", "/root" }
-        };
-        // clang-format on
+            {"syscall", "execve"},
+            {"pid", kExecveAuditEvent.syscall_data.process_id},
+            {"ppid", kExecveAuditEvent.syscall_data.parent_process_id},
+            {"auid", kExecveAuditEvent.syscall_data.auid},
+            {"uid", kExecveAuditEvent.syscall_data.uid},
+            {"euid", kExecveAuditEvent.syscall_data.euid},
+            {"gid", kExecveAuditEvent.syscall_data.gid},
+            {"egid", kExecveAuditEvent.syscall_data.egid},
+            {"exe", kExecveAuditEvent.syscall_data.exe},
+            {"exit", kExecveAuditEvent.syscall_data.exit_code},
+            {"cmdline", "\"-c\" \"echo hello world!\""},
+            {"path", "/usr/bin/bash"},
+            {"mode", static_cast<std::int64_t>(0755)},
+            {"ouid", static_cast<std::int64_t>(0)},
+            {"ogid", static_cast<std::int64_t>(0)},
+            {"inode", static_cast<std::int64_t>(806807)},
+            {"cwd", "/root"}};
 
         REQUIRE(row.size() == kExpectedColumnList.size() + 1);
 
@@ -119,8 +120,8 @@ SCENARIO("Row generation in the process_events table",
         1000,
         1000,
         1000,
-        "23eb8e0",
-        "\"/usr/bin/bash\""
+        "\"/usr/bin/bash\"",
+        "23eb8e0"
       },
 
       // Execve record data
@@ -144,25 +145,24 @@ SCENARIO("Row generation in the process_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedForkColumnList = {
-          { "syscall", "fork" },
-          { "pid", kForkAuditEvent.syscall_data.process_id },
-          { "parent", kForkAuditEvent.syscall_data.parent_process_id },
-          { "auid", kForkAuditEvent.syscall_data.auid },
-          { "uid", kForkAuditEvent.syscall_data.uid },
-          { "euid", kForkAuditEvent.syscall_data.euid },
-          { "gid", kForkAuditEvent.syscall_data.gid },
-          { "egid", kForkAuditEvent.syscall_data.egid },
-          { "owner_uid", { static_cast<std::int64_t>(0) } },
-          { "owner_gid", { static_cast<std::int64_t>(0) } },
-          { "cmdline_size", { static_cast<std::int64_t>(0) } },
-          { "cmdline", { "" } },
-          { "path", { "" } },
-          { "mode", { static_cast<std::int64_t>(0) } },
-          { "cwd", { "" } }
-        };
-        // clang-format on
+            {"syscall", "fork"},
+            {"pid", kForkAuditEvent.syscall_data.process_id},
+            {"ppid", kForkAuditEvent.syscall_data.parent_process_id},
+            {"auid", kForkAuditEvent.syscall_data.auid},
+            {"uid", kForkAuditEvent.syscall_data.uid},
+            {"euid", kForkAuditEvent.syscall_data.euid},
+            {"gid", kForkAuditEvent.syscall_data.gid},
+            {"egid", kForkAuditEvent.syscall_data.egid},
+            {"exe", kForkAuditEvent.syscall_data.exe},
+            {"exit", kForkAuditEvent.syscall_data.exit_code},
+            {"cmdline", {""}},
+            {"path", {""}},
+            {"mode", static_cast<std::int64_t>(0)},
+            {"ouid", static_cast<std::int64_t>(0)},
+            {"ogid", static_cast<std::int64_t>(0)},
+            {"inode", static_cast<std::int64_t>(0)},
+            {"cwd", {""}}};
 
         REQUIRE(row.size() == kExpectedForkColumnList.size() + 1);
         REQUIRE(row.count("time") != 0U);
@@ -188,8 +188,8 @@ SCENARIO("Row generation in the process_events table",
         2000,
         2000,
         2000,
-        "23eb8e0",
-        "\"/usr/bin/bash\""
+        "\"/usr/bin/bash\"",
+        "23eb8e0"
       },
 
       // Execve record data
@@ -214,25 +214,24 @@ SCENARIO("Row generation in the process_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedVForkColumnList = {
-          { "syscall", "vfork" },
-          { "pid", kVForkAuditEvent.syscall_data.process_id },
-          { "parent", kVForkAuditEvent.syscall_data.parent_process_id },
-          { "auid", kVForkAuditEvent.syscall_data.auid },
-          { "uid", kVForkAuditEvent.syscall_data.uid },
-          { "euid", kVForkAuditEvent.syscall_data.euid },
-          { "gid", kVForkAuditEvent.syscall_data.gid },
-          { "egid", kVForkAuditEvent.syscall_data.egid },
-          { "owner_uid", { static_cast<std::int64_t>(0) } },
-          { "owner_gid", { static_cast<std::int64_t>(0) } },
-          { "cmdline_size", { static_cast<std::int64_t>(0) } },
-          { "cmdline", { "" } },
-          { "path", { "" } },
-          { "mode", { static_cast<std::int64_t>(0) } },
-          { "cwd", { "" } }
-        };
-        // clang-format on
+            {"syscall", "vfork"},
+            {"pid", kVForkAuditEvent.syscall_data.process_id},
+            {"ppid", kVForkAuditEvent.syscall_data.parent_process_id},
+            {"auid", kVForkAuditEvent.syscall_data.auid},
+            {"uid", kVForkAuditEvent.syscall_data.uid},
+            {"euid", kVForkAuditEvent.syscall_data.euid},
+            {"gid", kVForkAuditEvent.syscall_data.gid},
+            {"egid", kVForkAuditEvent.syscall_data.egid},
+            {"exe", kVForkAuditEvent.syscall_data.exe},
+            {"exit", kVForkAuditEvent.syscall_data.exit_code},
+            {"cmdline", {""}},
+            {"path", {""}},
+            {"mode", static_cast<std::int64_t>(0)},
+            {"ouid", static_cast<std::int64_t>(0)},
+            {"ogid", static_cast<std::int64_t>(0)},
+            {"inode", static_cast<std::int64_t>(0)},
+            {"cwd", {""}}};
 
         REQUIRE(row.size() == kExpectedVForkColumnList.size() + 1);
         REQUIRE(row.count("time") != 0U);
@@ -258,8 +257,8 @@ SCENARIO("Row generation in the process_events table",
         3000,
         3000,
         3000,
-        "23eb8e0",
-        "\"/usr/bin/bash\""
+        "\"/usr/bin/bash\"",
+        "23eb8e0"
       },
 
       // Execve record data
@@ -284,25 +283,24 @@ SCENARIO("Row generation in the process_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedCloneColumnList = {
-          { "syscall", "clone" },
-          { "pid", kCloneAuditEvent.syscall_data.process_id },
-          { "parent", kCloneAuditEvent.syscall_data.parent_process_id },
-          { "auid", kCloneAuditEvent.syscall_data.auid },
-          { "uid", kCloneAuditEvent.syscall_data.uid },
-          { "euid", kCloneAuditEvent.syscall_data.euid },
-          { "gid", kCloneAuditEvent.syscall_data.gid },
-          { "egid", kCloneAuditEvent.syscall_data.egid },
-          { "owner_uid", { static_cast<std::int64_t>(0) } },
-          { "owner_gid", { static_cast<std::int64_t>(0) } },
-          { "cmdline_size", { static_cast<std::int64_t>(0) } },
-          { "cmdline", { "" } },
-          { "path", { "" } },
-          { "mode", { static_cast<std::int64_t>(0) } },
-          { "cwd", { "" } }
-        };
-        // clang-format on
+            {"syscall", "clone"},
+            {"pid", kCloneAuditEvent.syscall_data.process_id},
+            {"ppid", kCloneAuditEvent.syscall_data.parent_process_id},
+            {"auid", kCloneAuditEvent.syscall_data.auid},
+            {"uid", kCloneAuditEvent.syscall_data.uid},
+            {"euid", kCloneAuditEvent.syscall_data.euid},
+            {"gid", kCloneAuditEvent.syscall_data.gid},
+            {"egid", kCloneAuditEvent.syscall_data.egid},
+            {"exe", kCloneAuditEvent.syscall_data.exe},
+            {"exit", kCloneAuditEvent.syscall_data.exit_code},
+            {"cmdline", {""}},
+            {"path", {""}},
+            {"mode", static_cast<std::int64_t>(0)},
+            {"ouid", static_cast<std::int64_t>(0)},
+            {"ogid", static_cast<std::int64_t>(0)},
+            {"inode", static_cast<std::int64_t>(0)},
+            {"cwd", {""}}};
 
         REQUIRE(row.size() == kExpectedCloneColumnList.size() + 1);
         REQUIRE(row.count("time") != 0U);

--- a/tables/audisp/tests/socketeventstableplugin.cpp
+++ b/tables/audisp/tests/socketeventstableplugin.cpp
@@ -54,21 +54,23 @@ SCENARIO("Row generation in the socket_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedConnectColumnList = {
-          { "action", "connect" },
-          { "pid", static_cast<std::int64_t>(38031) },
-          { "path", "/usr/bin/curl" },
-          { "fd", static_cast<std::int64_t>(16) },
-          { "auid", static_cast<std::int64_t>(1000) },
-          { "success", static_cast<std::int64_t>(1) },
-          { "family", static_cast<std::int64_t>(2) },
-          { "local_address", { "" } },
-          { "remote_address", "127.0.0.1" },
-          { "local_port", { static_cast<std::int64_t>(0) } },
-          { "remote_port", static_cast<std::int64_t>(443) }
-        };
-        // clang-format on
+            {"syscall", "connect"},
+            {"pid", kConnectAuditEvent.syscall_data.process_id},
+            {"ppid", kConnectAuditEvent.syscall_data.parent_process_id},
+            {"auid", kConnectAuditEvent.syscall_data.auid},
+            {"uid", kConnectAuditEvent.syscall_data.uid},
+            {"euid", kConnectAuditEvent.syscall_data.euid},
+            {"gid", kConnectAuditEvent.syscall_data.gid},
+            {"egid", kConnectAuditEvent.syscall_data.egid},
+            {"exe", "/usr/bin/curl"},
+            {"fd", static_cast<std::int64_t>(16)},
+            {"success", static_cast<std::int64_t>(1)},
+            {"family", static_cast<std::int64_t>(2)},
+            {"local_address", {""}},
+            {"remote_address", "127.0.0.1"},
+            {"local_port", {static_cast<std::int64_t>(0)}},
+            {"remote_port", static_cast<std::int64_t>(443)}};
 
         REQUIRE(row.size() == kExpectedConnectColumnList.size() + 1);
         REQUIRE(row.count("time") != 0U);
@@ -125,21 +127,23 @@ SCENARIO("Row generation in the socket_events table",
       REQUIRE(status.succeeded());
 
       THEN("rows are generated correctly") {
-        // clang-format off
         static ExpectedValueList kExpectedBindColumnList = {
-          { "action", "bind" },
-          { "pid", static_cast<std::int64_t>(38031) },
-          { "path", "/usr/bin/curl" },
-          { "fd", static_cast<std::int64_t>(16) },
-          { "auid", static_cast<std::int64_t>(1000) },
-          { "success", static_cast<std::int64_t>(1) },
-          { "family", static_cast<std::int64_t>(2) },
-          { "local_address", "0.0.0.0" },
-          { "remote_address", { "" } },
-          { "local_port", static_cast<std::int64_t>(8080) },
-          { "remote_port", { static_cast<std::int64_t>(0) } }
-        };
-        // clang-format on
+            {"syscall", "bind"},
+            {"pid", kBindAuditEvent.syscall_data.process_id},
+            {"ppid", kBindAuditEvent.syscall_data.parent_process_id},
+            {"auid", kBindAuditEvent.syscall_data.auid},
+            {"uid", kBindAuditEvent.syscall_data.uid},
+            {"euid", kBindAuditEvent.syscall_data.euid},
+            {"gid", kBindAuditEvent.syscall_data.gid},
+            {"egid", kBindAuditEvent.syscall_data.egid},
+            {"exe", "/usr/bin/curl"},
+            {"fd", static_cast<std::int64_t>(16)},
+            {"success", static_cast<std::int64_t>(1)},
+            {"family", static_cast<std::int64_t>(2)},
+            {"local_address", "0.0.0.0"},
+            {"remote_address", {""}},
+            {"local_port", static_cast<std::int64_t>(8080)},
+            {"remote_port", {static_cast<std::int64_t>(0)}}};
 
         REQUIRE(row.size() == kExpectedBindColumnList.size() + 1);
         REQUIRE(row.count("time") != 0U);

--- a/tables/endpointsecurity/CMakeLists.txt
+++ b/tables/endpointsecurity/CMakeLists.txt
@@ -8,6 +8,9 @@ function(zeekAgentTablesEndpointSecurity)
     src/processeventstableplugin.h
     src/processeventstableplugin.cpp
 
+    src/fileeventstableplugin.h
+    src/fileeventstableplugin.cpp
+
     src/endpointsecurityservice.h
     src/endpointsecurityservice.cpp
   )
@@ -36,6 +39,7 @@ function(zeekAgentTablesEndpointSecurity)
     SOURCES
       tests/main.cpp
       tests/processeventstableplugin.cpp
+      tests/fileeventstableplugin.cpp
   )
 endfunction()
 

--- a/tables/endpointsecurity/src/endpointsecurityservice.cpp
+++ b/tables/endpointsecurity/src/endpointsecurityservice.cpp
@@ -1,4 +1,5 @@
 #include "endpointsecurityservice.h"
+#include "fileeventstableplugin.h"
 #include "processeventstableplugin.h"
 
 #include <algorithm>
@@ -27,17 +28,21 @@ struct EndpointSecurityService::PrivateData final {
   IEndpointSecurityConsumer::Ref endpoint_sec_consumer;
 
   IVirtualTable::Ref process_events_table;
+  IVirtualTable::Ref file_events_table;
 };
 
 EndpointSecurityService::~EndpointSecurityService() {
-  if (!d->process_events_table) {
-    return;
+  if (d->process_events_table) {
+    auto status =
+        d->virtual_database.unregisterTable(d->process_events_table->name());
+    assert(status.succeeded() &&
+           "Failed to unregister the process_events table");
   }
-
-  auto status =
-      d->virtual_database.unregisterTable(d->process_events_table->name());
-
-  assert(status.succeeded() && "Failed to unregister the process_events table");
+  if (d->file_events_table) {
+    auto status =
+        d->virtual_database.unregisterTable(d->file_events_table->name());
+    assert(status.succeeded() && "Failed to unregister the file_events table");
+  }
 }
 
 const std::string &EndpointSecurityService::name() const {
@@ -46,7 +51,9 @@ const std::string &EndpointSecurityService::name() const {
 
 Status EndpointSecurityService::exec(std::atomic_bool &terminate) {
   while (!terminate) {
-    if (!d->process_events_table) {
+    if (!d->process_events_table || !d->file_events_table) {
+      d->logger.logMessage(IZeekLogger::Severity::Information,
+                           "Table(s) not created yet, sleeping for 1 second");
       std::this_thread::sleep_for(std::chrono::seconds(1U));
       continue;
     }
@@ -54,7 +61,11 @@ Status EndpointSecurityService::exec(std::atomic_bool &terminate) {
     auto &process_events_table_impl =
         *static_cast<ProcessEventsTablePlugin *>(d->process_events_table.get());
 
+    auto &file_events_table_impl =
+        *static_cast<FileEventsTablePlugin *>(d->file_events_table.get());
+
     IEndpointSecurityConsumer::EventList event_list;
+
     d->endpoint_sec_consumer->getEvents(event_list);
 
     if (event_list.empty()) {
@@ -66,6 +77,14 @@ Status EndpointSecurityService::exec(std::atomic_bool &terminate) {
       d->logger.logMessage(
           IZeekLogger::Severity::Error,
           "The process_events table failed to process some events: " +
+              status.message());
+    }
+
+    status = file_events_table_impl.processEvents(event_list);
+    if (!status.succeeded()) {
+      d->logger.logMessage(
+          IZeekLogger::Severity::Error,
+          "The file_events table failed to process some events: " +
               status.message());
     }
   }
@@ -82,10 +101,11 @@ EndpointSecurityService::EndpointSecurityService(
                                                   logger, configuration);
 
   if (!status.succeeded()) {
-    d->logger.logMessage(IZeekLogger::Severity::Error,
-                         "Failed to connect to the EndpointSecurity API. The "
-                         "process_events table will not be enabled. Error: " +
-                             status.message());
+    d->logger.logMessage(
+        IZeekLogger::Severity::Error,
+        "Failed to connect to the EndpointSecurity API. The "
+        "process_events and file_events tables will not be enabled. Error: " +
+            status.message());
 
     return;
   }
@@ -97,6 +117,17 @@ EndpointSecurityService::EndpointSecurityService(
   }
 
   status = d->virtual_database.registerTable(d->process_events_table);
+  if (!status.succeeded()) {
+    throw status;
+  }
+
+  status = FileEventsTablePlugin::create(d->file_events_table, configuration,
+                                         logger);
+  if (!status.succeeded()) {
+    throw status;
+  }
+
+  status = d->virtual_database.registerTable(d->file_events_table);
   if (!status.succeeded()) {
     throw status;
   }

--- a/tables/endpointsecurity/src/fileeventstableplugin.h
+++ b/tables/endpointsecurity/src/fileeventstableplugin.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <zeek/iendpointsecurityconsumer.h>
+#include <zeek/ivirtualtable.h>
+#include <zeek/izeekconfiguration.h>
+#include <zeek/izeeklogger.h>
+
+namespace zeek {
+/// \brief Provides the file_events table
+class FileEventsTablePlugin final : public IVirtualTable {
+  struct PrivateData;
+  std::unique_ptr<PrivateData> d;
+
+public:
+  /// \brief Factory method
+  /// \param obj Where the created object is stored
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  /// \return A Status object
+  static Status create(Ref &obj, IZeekConfiguration &configuration,
+                       IZeekLogger &logger);
+
+  /// \brief Destructor
+  virtual ~FileEventsTablePlugin() override;
+
+  /// \return The table name
+  virtual const std::string &name() const override;
+
+  /// \return The table schema
+  virtual const Schema &schema() const override;
+
+  /// \brief Generates the row list containing the fields from the given
+  ///        configuration object
+  /// \param row_list Where the generated rows are stored
+  /// \return A Status object
+  virtual Status generateRowList(RowList &row_list) override;
+
+  /// \brief Processes the specified event list, generating new rows
+  /// \param event_list A list of EndpointSecurity events
+  /// \return A Status object
+  Status processEvents(const IEndpointSecurityConsumer::EventList &event_list);
+
+protected:
+  /// \brief Constructor
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  FileEventsTablePlugin(IZeekConfiguration &configuration, IZeekLogger &logger);
+
+public:
+  /// \brief Generates a single row from the given EndpointSecurity event
+  /// \param event a single EndpointSecurity event
+  /// \return A Status object
+  static Status generateRow(Row &row,
+                            const IEndpointSecurityConsumer::Event &event);
+};
+} // namespace zeek

--- a/tables/openbsm/CMakeLists.txt
+++ b/tables/openbsm/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.16.3)
+
+function(zeekAgentTablesOpenbsm)
+  add_library(zeek_openbsm_tables
+    include/zeek/openbsmservicefactory.h
+    src/openbsmservicefactory.cpp
+
+          src/openbsmservice.h
+    src/openbsmservice.cpp
+          src/socketeventstableplugin.cpp
+          src/socketeventstableplugin.h
+  )
+
+  target_include_directories(zeek_openbsm_tables PRIVATE
+    include
+  )
+
+  target_include_directories(zeek_openbsm_tables SYSTEM INTERFACE
+    include
+  )
+
+  target_link_libraries(zeek_openbsm_tables PUBLIC
+    zeek_openbsm
+    zeek_database
+    zeek_configuration
+    zeek_service_manager
+  )
+
+  target_link_libraries(zeek_tables INTERFACE zeek_openbsm_tables)
+
+  generateZeekAgentTest(
+    SOURCE_TARGET
+      "zeek_openbsm_tables"
+
+    SOURCES
+      tests/main.cpp
+      tests/socketeventstableplugin.cpp
+  )
+endfunction()
+
+zeekAgentTablesOpenbsm()

--- a/tables/openbsm/CMakeLists.txt
+++ b/tables/openbsm/CMakeLists.txt
@@ -5,10 +5,10 @@ function(zeekAgentTablesOpenbsm)
     include/zeek/openbsmservicefactory.h
     src/openbsmservicefactory.cpp
 
-          src/openbsmservice.h
+    src/openbsmservice.h
     src/openbsmservice.cpp
-          src/socketeventstableplugin.cpp
-          src/socketeventstableplugin.h
+    src/socketeventstableplugin.cpp
+    src/socketeventstableplugin.h
   )
 
   target_include_directories(zeek_openbsm_tables PRIVATE

--- a/tables/openbsm/include/zeek/openbsmservicefactory.h
+++ b/tables/openbsm/include/zeek/openbsmservicefactory.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <zeek/izeekconfiguration.h>
+#include <zeek/izeekservicemanager.h>
+
+namespace zeek {
+/// \brief Factory method for the EndpointSecurityServiceFactory object
+/// \param service_manager An initialized service manager
+/// \param virtual_database The database where the EndpointSecurity tables
+///                         are registered
+/// \param configuration An initialized configuration object
+/// \param logger An initialized logger object
+Status registerOpenbsmServiceFactory(IZeekServiceManager &service_manager,
+                                     IVirtualDatabase &virtual_database,
+                                     IZeekConfiguration &configuration,
+                                     IZeekLogger &logger);
+
+} // namespace zeek

--- a/tables/openbsm/include/zeek/openbsmservicefactory.h
+++ b/tables/openbsm/include/zeek/openbsmservicefactory.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <zeek/ivirtualdatabase.h>
 #include <zeek/izeekconfiguration.h>
+#include <zeek/izeeklogger.h>
 #include <zeek/izeekservicemanager.h>
+#include <zeek/status.h>
 
 namespace zeek {
 /// \brief Factory method for the EndpointSecurityServiceFactory object

--- a/tables/openbsm/src/openbsmservice.cpp
+++ b/tables/openbsm/src/openbsmservice.cpp
@@ -1,0 +1,164 @@
+#include "openbsmservice.h"
+#include "socketeventstableplugin.h"
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <thread>
+
+#include <zeek/iopenbsmconsumer.h>
+#include <zeek/openbsmservicefactory.h>
+
+namespace zeek {
+namespace {
+const std::string kServiceName{"openbsm"};
+} // namespace
+
+struct OpenbsmService::PrivateData final {
+  PrivateData(IVirtualDatabase &virtual_database_,
+              IZeekConfiguration &configuration_, IZeekLogger &logger_)
+      : virtual_database(virtual_database_), configuration(configuration_),
+        logger(logger_) {}
+
+  IVirtualDatabase &virtual_database;
+  IZeekConfiguration &configuration;
+  IZeekLogger &logger;
+
+  IOpenbsmConsumer::Ref openbsm_consumer;
+
+  IVirtualTable::Ref socket_events_table;
+};
+
+OpenbsmService::~OpenbsmService() {
+  if (d->socket_events_table) {
+    auto status =
+        d->virtual_database.unregisterTable(d->socket_events_table->name());
+    assert(status.succeeded() &&
+           "Failed to unregister the socket_events table");
+  }
+}
+
+const std::string &OpenbsmService::name() const { return kServiceName; }
+
+Status OpenbsmService::exec(std::atomic_bool &terminate) {
+
+  while (!terminate) {
+
+    if (!d->socket_events_table) {
+      d->logger.logMessage(IZeekLogger::Severity::Information,
+                           "Table(s) not created yet, sleeping for 1 second");
+      std::this_thread::sleep_for(std::chrono::seconds(1U));
+      continue;
+    }
+
+    auto &socket_events_table_impl =
+        *static_cast<SocketEventsTablePlugin *>(d->socket_events_table.get());
+
+    IOpenbsmConsumer::EventList event_list;
+
+    d->openbsm_consumer->getEvents(event_list);
+
+    if (event_list.empty()) {
+      continue;
+    }
+
+    auto status = socket_events_table_impl.processEvents(event_list);
+    if (!status.succeeded()) {
+      d->logger.logMessage(
+          IZeekLogger::Severity::Error,
+          "The socket_events table failed to process some events: " +
+              status.message());
+    }
+  }
+
+  return Status::success();
+}
+
+OpenbsmService::OpenbsmService(IVirtualDatabase &virtual_database,
+                               IZeekConfiguration &configuration,
+                               IZeekLogger &logger)
+    : d(new PrivateData(virtual_database, configuration, logger)) {
+
+  auto status =
+      IOpenbsmConsumer::create(d->openbsm_consumer, logger, configuration);
+
+  if (!status.succeeded()) {
+    d->logger.logMessage(IZeekLogger::Severity::Error,
+                         "Failed to connect to the Openbsm API. The "
+                         "socket_events tables will not be enabled. Error: " +
+                             status.message());
+
+    return;
+  }
+
+  status = SocketEventsTablePlugin::create(d->socket_events_table,
+                                           configuration, logger);
+  if (!status.succeeded()) {
+    throw status;
+  }
+
+  status = d->virtual_database.registerTable(d->socket_events_table);
+  if (!status.succeeded()) {
+    throw status;
+  }
+}
+
+struct OpenbsmServiceFactory::PrivateData final {
+  PrivateData(IVirtualDatabase &virtual_database_,
+              IZeekConfiguration &configuration_, IZeekLogger &logger_)
+      : virtual_database(virtual_database_), configuration(configuration_),
+        logger(logger_) {}
+
+  IVirtualDatabase &virtual_database;
+  IZeekConfiguration &configuration;
+  IZeekLogger &logger;
+};
+
+Status OpenbsmServiceFactory::create(Ref &obj,
+                                     IVirtualDatabase &virtual_database,
+                                     IZeekConfiguration &configuration,
+                                     IZeekLogger &logger) {
+  obj.reset();
+
+  try {
+    auto ptr =
+        new OpenbsmServiceFactory(virtual_database, configuration, logger);
+    obj.reset(ptr);
+
+    return Status::success();
+
+  } catch (const std::bad_alloc &) {
+    return Status::failure("Memory allocation failure");
+
+  } catch (const Status &status) {
+    return status;
+  }
+}
+
+OpenbsmServiceFactory::~OpenbsmServiceFactory() {}
+
+const std::string &OpenbsmServiceFactory::name() const { return kServiceName; }
+
+Status OpenbsmServiceFactory::spawn(IZeekService::Ref &obj) {
+  obj.reset();
+
+  try {
+    obj.reset(
+        new OpenbsmService(d->virtual_database, d->configuration, d->logger));
+
+    return Status::success();
+
+  } catch (const std::bad_alloc &) {
+    return Status::failure("Memory allocation failure");
+
+  } catch (const Status &status) {
+    return status;
+  }
+}
+
+OpenbsmServiceFactory::OpenbsmServiceFactory(IVirtualDatabase &virtual_database,
+                                             IZeekConfiguration &configuration,
+                                             IZeekLogger &logger)
+    : d(new PrivateData(virtual_database, configuration, logger)) {}
+
+} // namespace zeek

--- a/tables/openbsm/src/openbsmservice.h
+++ b/tables/openbsm/src/openbsmservice.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <zeek/izeekconfiguration.h>
+#include <zeek/izeeklogger.h>
+#include <zeek/izeekservicemanager.h>
+
+namespace zeek {
+/// \brief An Zeek service that acts as EndpointSecurity event publisher
+class OpenbsmService final : public IZeekService {
+  struct PrivateData;
+  std::unique_ptr<PrivateData> d;
+
+public:
+  /// \brief Destructor
+  virtual ~OpenbsmService() override;
+
+  /// \return The service name
+  virtual const std::string &name() const override;
+
+  /// \brief Starts the service until it is interrupted
+  /// \param terminate Set to true when the service should terminate
+  /// \return A Status object
+  virtual Status exec(std::atomic_bool &terminate) override;
+
+  OpenbsmService(const OpenbsmService &) = delete;
+  OpenbsmService &operator=(const OpenbsmService &) = delete;
+
+protected:
+  /// \brief Constructor
+  /// \param virtual_database The database where the EndpointSecurity table
+  ///                         are registered
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  OpenbsmService(IVirtualDatabase &virtual_database,
+                 IZeekConfiguration &configuration, IZeekLogger &logger);
+
+  friend class OpenbsmServiceFactory;
+};
+
+/// \brief The factort for the EndpointSecurity service
+class OpenbsmServiceFactory final : public IZeekServiceFactory {
+  struct PrivateData;
+  std::unique_ptr<PrivateData> d;
+
+public:
+  /// \brief Factory method
+  /// \param obj Where the new object is stored
+  /// \param virtual_database The database where the EndpointSecurity table
+  ///                         are registered
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  static Status create(Ref &obj, IVirtualDatabase &virtual_database,
+                       IZeekConfiguration &configuration, IZeekLogger &logger);
+
+  /// \brief Destructor
+  virtual ~OpenbsmServiceFactory() override;
+
+  /// \return The service factory name
+  virtual const std::string &name() const override;
+
+  /// \brief Creates a new EndpointSecurity service
+  /// \param obj Where the created object is stored
+  /// \return A Status object
+  virtual Status spawn(IZeekService::Ref &obj) override;
+
+protected:
+  /// \brief Constructor
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  OpenbsmServiceFactory(IVirtualDatabase &virtual_database,
+                        IZeekConfiguration &configuration, IZeekLogger &logger);
+};
+} // namespace zeek

--- a/tables/openbsm/src/openbsmservicefactory.cpp
+++ b/tables/openbsm/src/openbsmservicefactory.cpp
@@ -1,0 +1,26 @@
+#include "openbsmservice.h"
+
+namespace zeek {
+Status registerOpenbsmServiceFactory(IZeekServiceManager &service_manager,
+                                     IVirtualDatabase &virtual_database,
+                                     IZeekConfiguration &configuration,
+                                     IZeekLogger &logger) {
+
+  OpenbsmServiceFactory::Ref openbsm_service_factory;
+  auto status = OpenbsmServiceFactory::create(
+      openbsm_service_factory, virtual_database, configuration, logger);
+
+  if (!status.succeeded()) {
+    return status;
+  }
+
+  status = service_manager.registerServiceFactory(
+      std::move(openbsm_service_factory));
+
+  if (!status.succeeded()) {
+    return status;
+  }
+
+  return Status::success();
+}
+} // namespace zeek

--- a/tables/openbsm/src/socketeventstableplugin.cpp
+++ b/tables/openbsm/src/socketeventstableplugin.cpp
@@ -1,0 +1,168 @@
+#include "socketeventstableplugin.h"
+
+#include <chrono>
+#include <limits>
+#include <mutex>
+
+namespace zeek {
+struct SocketEventsTablePlugin::PrivateData final {
+  PrivateData(IZeekConfiguration &configuration_, IZeekLogger &logger_)
+      : configuration(configuration_), logger(logger_) {}
+
+  IZeekConfiguration &configuration;
+  IZeekLogger &logger;
+
+  RowList row_list;
+  std::mutex row_list_mutex;
+  std::size_t max_queued_row_count{0U};
+};
+
+Status SocketEventsTablePlugin::create(Ref &obj,
+                                       IZeekConfiguration &configuration,
+                                       IZeekLogger &logger) {
+
+  try {
+    obj.reset(new SocketEventsTablePlugin(configuration, logger));
+
+    return Status::success();
+
+  } catch (const std::bad_alloc &) {
+    return Status::failure("Memory allocation failure");
+
+  } catch (const Status &status) {
+    return status;
+  }
+}
+
+SocketEventsTablePlugin::~SocketEventsTablePlugin() {}
+
+const std::string &SocketEventsTablePlugin::name() const {
+  static const std::string kTableName{"socket_events"};
+
+  return kTableName;
+}
+
+const SocketEventsTablePlugin::Schema &SocketEventsTablePlugin::schema() const {
+
+  static const Schema kTableSchema = {
+      {"timestamp", IVirtualTable::ColumnType::Integer},
+      {"type", IVirtualTable::ColumnType::String},
+      {"process_id", IVirtualTable::ColumnType::Integer},
+      {"user_id", IVirtualTable::ColumnType::Integer},
+      {"group_id", IVirtualTable::ColumnType::Integer},
+      {"path", IVirtualTable::ColumnType::String},
+      {"family", IVirtualTable::ColumnType::Integer},
+      {"success", IVirtualTable::ColumnType::Integer},
+      {"local_address", IVirtualTable::ColumnType::String},
+      {"local_port", IVirtualTable::ColumnType::Integer},
+      {"remote_address", IVirtualTable::ColumnType::String},
+      {"remote_port", IVirtualTable::ColumnType::Integer}};
+
+  return kTableSchema;
+}
+
+Status SocketEventsTablePlugin::generateRowList(RowList &row_list) {
+  std::lock_guard<std::mutex> lock(d->row_list_mutex);
+
+  row_list = std::move(d->row_list);
+  d->row_list = {};
+
+  return Status::success();
+}
+
+Status SocketEventsTablePlugin::processEvents(
+    const IOpenbsmConsumer::EventList &event_list) {
+
+  for (const auto &event : event_list) {
+    Row row;
+
+    auto status = generateRow(row, event);
+    if (!status.succeeded()) {
+      return status;
+    }
+
+    if (!row.empty()) {
+      {
+        std::lock_guard<std::mutex> lock(d->row_list_mutex);
+        d->row_list.push_back(row);
+      }
+    }
+  }
+
+  if (d->row_list.size() > d->max_queued_row_count) {
+
+    auto rows_to_remove = d->row_list.size() - d->max_queued_row_count;
+
+    d->logger.logMessage(IZeekLogger::Severity::Warning,
+                         "socket_events: Dropping " +
+                             std::to_string(rows_to_remove) +
+                             " rows (max row count is set to " +
+                             std::to_string(d->max_queued_row_count) + ")");
+
+    {
+      std::lock_guard<std::mutex> lock(d->row_list_mutex);
+      d->row_list.erase(d->row_list.begin(),
+                        std::next(d->row_list.begin(), rows_to_remove));
+    }
+  }
+
+  return Status::success();
+}
+
+SocketEventsTablePlugin::SocketEventsTablePlugin(
+    IZeekConfiguration &configuration, IZeekLogger &logger)
+    : d(new PrivateData(configuration, logger)) {
+  d->max_queued_row_count = d->configuration.maxQueuedRowCount();
+}
+
+Status
+SocketEventsTablePlugin::generateRow(Row &row,
+                                     const IOpenbsmConsumer::Event &event) {
+
+  row = {};
+
+  std::string action;
+
+  switch (event.type) {
+  case IOpenbsmConsumer::Event::Type::Bind:
+    action = "bind";
+    break;
+  case IOpenbsmConsumer::Event::Type::Connect:
+    action = "connect";
+    break;
+  default:
+    return Status::success();
+  }
+  const auto &header = event.header;
+  assert((header.timestamp <= std::numeric_limits<int64_t>::max()) &&
+         "Failed to cast timestamp to int64_t");
+  row["timestamp"] = static_cast<std::int64_t>(header.timestamp);
+  row["type"] = std::move(action);
+  row["process_id"] = static_cast<std::int64_t>(header.process_id);
+  row["user_id"] = static_cast<std::int64_t>(header.user_id);
+  row["group_id"] = static_cast<std::int64_t>(header.group_id);
+  row["path"] = header.path;
+  row["family"] = static_cast<std::int64_t>(header.family);
+  row["success"] = static_cast<std::int64_t>(header.success);
+
+  std::int64_t null_value{0};
+
+  if (event.type == IOpenbsmConsumer::Event::Type::Bind) {
+
+    row["local_address"] = header.local_address;
+    row["local_port"] = static_cast<std::int64_t>(header.local_port);
+
+    row["remote_address"] = {""};
+    row["remote_port"] = {null_value};
+
+  } else {
+    row["local_address"] = {""};
+    row["local_port"] = {null_value};
+
+    row["remote_address"] = header.remote_address;
+    row["remote_port"] = static_cast<std::int64_t>(header.remote_port);
+  }
+
+  return Status::success();
+}
+} // namespace zeek

--- a/tables/openbsm/src/socketeventstableplugin.h
+++ b/tables/openbsm/src/socketeventstableplugin.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <zeek/iopenbsmconsumer.h>
+#include <zeek/ivirtualtable.h>
+#include <zeek/izeekconfiguration.h>
+#include <zeek/izeeklogger.h>
+
+namespace zeek {
+/// \brief Provides the file_events table
+class SocketEventsTablePlugin final : public IVirtualTable {
+  struct PrivateData;
+  std::unique_ptr<PrivateData> d;
+
+public:
+  /// \brief Factory method
+  /// \param obj Where the created object is stored
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  /// \return A Status object
+  static Status create(Ref &obj, IZeekConfiguration &configuration,
+                       IZeekLogger &logger);
+
+  /// \brief Destructor
+  virtual ~SocketEventsTablePlugin() override;
+
+  /// \return The table name
+  virtual const std::string &name() const override;
+
+  /// \return The table schema
+  virtual const Schema &schema() const override;
+
+  /// \brief Generates the row list containing the fields from the given
+  ///        configuration object
+  /// \param row_list Where the generated rows are stored
+  /// \return A Status object
+  virtual Status generateRowList(RowList &row_list) override;
+
+  /// \brief Processes the specified event list, generating new rows
+  /// \param event_list A list of EndpointSecurity events
+  /// \return A Status object
+  Status processEvents(const IOpenbsmConsumer::EventList &event_list);
+
+protected:
+  /// \brief Constructor
+  /// \param configuration An initialized configuration object
+  /// \param logger An initialized logger object
+  SocketEventsTablePlugin(IZeekConfiguration &configuration,
+                          IZeekLogger &logger);
+
+public:
+  /// \brief Generates a single row from the given EndpointSecurity event
+  /// \param event a single EndpointSecurity event
+  /// \return A Status object
+  static Status generateRow(Row &row, const IOpenbsmConsumer::Event &event);
+};
+} // namespace zeek

--- a/tables/openbsm/tests/main.cpp
+++ b/tables/openbsm/tests/main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/tables/openbsm/tests/socketeventstableplugin.cpp
+++ b/tables/openbsm/tests/socketeventstableplugin.cpp
@@ -1,0 +1,119 @@
+#include "socketeventstableplugin.h"
+
+#include <catch2/catch.hpp>
+
+namespace zeek {
+namespace {
+IOpenbsmConsumer::Event generateEvent(IOpenbsmConsumer::Event::Type type) {
+  IOpenbsmConsumer::Event event;
+  event.header.timestamp = 1U;
+  event.header.process_id = 2U;
+  event.header.user_id = 3U;
+  event.header.group_id = 4U;
+  event.header.path = "/path/to/application";
+  event.header.success = 1;
+  event.header.family = 2;
+
+  if (type == IOpenbsmConsumer::Event::Type::Bind) {
+    event.type = type;
+    event.header.remote_address = "";
+    event.header.remote_port = 0;
+
+    event.header.local_address = "192.168.1.1";
+    event.header.local_port = 9876;
+
+  } else if (type == IOpenbsmConsumer::Event::Type::Connect) {
+    event.type = type;
+
+    event.header.local_address = "";
+    event.header.local_port = 0;
+
+    event.header.remote_address = "192.168.1.1";
+    event.header.remote_port = 9876;
+
+  } else {
+    FAIL("Invalid event type specified");
+  }
+
+  return event;
+}
+
+void validateRow(const IVirtualTable::Row &row,
+                 const IOpenbsmConsumer::Event &event) {
+
+  auto valid_event = event.type == IOpenbsmConsumer::Event::Type::Bind ||
+                     event.type == IOpenbsmConsumer::Event::Type::Connect;
+
+  REQUIRE(valid_event);
+
+  CHECK(row.size() == 12U);
+
+  CHECK(std::get<std::int64_t>(row.at("timestamp").value()) ==
+        event.header.timestamp);
+
+  CHECK(std::get<std::int64_t>(row.at("process_id").value()) ==
+        event.header.process_id);
+
+  CHECK(std::get<std::int64_t>(row.at("user_id").value()) ==
+        event.header.user_id);
+
+  CHECK(std::get<std::int64_t>(row.at("group_id").value()) ==
+        event.header.group_id);
+
+  CHECK(std::get<std::string>(row.at("path").value()) == event.header.path);
+
+  CHECK(std::get<std::int64_t>(row.at("success").value()) ==
+        event.header.success);
+
+  CHECK(std::get<std::int64_t>(row.at("family").value()) ==
+        event.header.family);
+
+  CHECK(std::get<std::string>(row.at("remote_address").value()) ==
+        event.header.remote_address);
+
+  CHECK(std::get<std::int64_t>(row.at("remote_port").value()) ==
+        event.header.remote_port);
+
+  CHECK(std::get<std::string>(row.at("local_address").value()) ==
+        event.header.local_address);
+
+  CHECK(std::get<std::int64_t>(row.at("local_port").value()) ==
+        event.header.local_port);
+
+  if (event.type == IOpenbsmConsumer::Event::Type::Bind) {
+    CHECK(std::get<std::string>(row.at("type").value()) == "bind");
+
+  } else {
+    CHECK(std::get<std::string>(row.at("type").value()) == "connect");
+  }
+}
+} // namespace
+
+SCENARIO("Row generation in the socket_events table",
+         "[SocketEventsTablePlugin]") {
+
+  GIVEN("a valid bind OpenBSM event") {
+    auto event = generateEvent(IOpenbsmConsumer::Event::Type::Bind);
+
+    WHEN("generating a table row") {
+      IVirtualTable::Row row;
+      auto status = SocketEventsTablePlugin::generateRow(row, event);
+      CHECK(status.succeeded());
+
+      validateRow(row, event);
+    }
+  }
+
+  GIVEN("a valid Connect OpenBSM event") {
+    auto event = generateEvent(IOpenbsmConsumer::Event::Type::Connect);
+
+    WHEN("generating table rows") {
+      IVirtualTable::Row row;
+      auto status = SocketEventsTablePlugin::generateRow(row, event);
+      CHECK(status.succeeded());
+
+      validateRow(row, event);
+    }
+  }
+}
+} // namespace zeek


### PR DESCRIPTION
Currently, Zeek-agent uses Endpoint Security framework service to collect file and process events on macOS; however, the Endpoint Security framework does not support socket events. Thus, to collect `connect` and `bind` socket events, this PR adds OpenBSM service. 

To use this service, the user only needs to add `nt` flag in `/etc/security/audit_control` configuration file of OpenBSM. After that socket events can be read from `/dev/auditpipe`. This PR takes care of reading events from that pipe and make socket events table. 

This OpenBSM service runs concurrently with Endpoint Security service which allows Zeek-agent to collect file, process, and socket events at the same time. 