### PR TITLE
Updating information regarding zeek-agent in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # Zeek Agent
 
-The *Zeek Agent* is an endpoint monitoring tool for Linux that
-reports, by default, socket and process events to
-[Zeek](https://zeek.org). Event data is captured from Audit using the
-Unix domain socket plugin that comes with Audisp, and is then
-presented to Zeek as an SQL database (using SQLite virtual tables
-internally).
+The *Zeek Agent* is an endpoint monitoring tool for Linux and macOS that
+reports, by default, file, socket, and process events to
+[Zeek](https://zeek.org). On Linux platform, event data is captured from [Linux
+Audit](https://linux.die.net/man/8/auditd) using the Unix domain socket plugin
+that comes with [Audisp](https://linux.die.net/man/8/audispd). On macOS
+platform, Zeek Agent leverages [Endpoint
+Security](https://developer.apple.com/documentation/endpointsecurity) framework
+to capture file and process events while to collect socket events Zeek Agent
+uses [OpenBSM](http://www.trustedbsd.org/openbsm.html).  Collected event data
+from endpoint is stored in an SQL database (using SQLite virtual tables
+internally) on the host. Events from this database are later fetched by Zeek
+using scheduled queries.
 
-Zeek-Agent can optionally also interface to
-[osquery](https://www.osquery.io), allowing Zeek to access almost all
-the endpoint information that it provides (excluding only evented
-tables).
+Zeek Agent can optionally also interface to [osquery](https://www.osquery.io),
+allowing Zeek to access almost all the endpoint information that it provides
+(excluding only event tables).
 
 Pre-built, statically linked `zeek-agent` packages are available on
 the [releases page](https://github.com/zeek/zeek-agent/releases).
@@ -24,9 +29,9 @@ endpoint activity into Zeek logs.
 
 The documentation has been moved to the [Zeek Agent
 Wiki](https://github.com/zeek/zeek-agent/wiki), and contains
-guides on building, configuring and extending the Zeek Agent project.
+guides on building, configuring, and extending the Zeek Agent project.
 
-For convenience, the build and configuration guides can be accessed from the following links:
+For convenience, use following links to build and configure Zeek Agent:
 - [Build Guide](https://github.com/zeek/zeek-agent/wiki/Build-Guide)
 - [Configuration Guide](https://github.com/zeek/zeek-agent/wiki/Configuration-Guide)
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 The *Zeek Agent* is an endpoint monitoring tool for Linux and macOS that
 reports, by default, file, socket, and process events to
-[Zeek](https://zeek.org). On Linux platform, event data is captured from [Linux
+[Zeek](https://zeek.org). On Linux, event data is captured from [Linux
 Audit](https://linux.die.net/man/8/auditd) using the Unix domain socket plugin
-that comes with [Audisp](https://linux.die.net/man/8/audispd). On macOS
-platform, Zeek Agent leverages [Endpoint
+that comes with [Audisp](https://linux.die.net/man/8/audispd). On macOS,
+Zeek Agent leverages [Endpoint
 Security](https://developer.apple.com/documentation/endpointsecurity) framework
 to capture file and process events while to collect socket events Zeek Agent
 uses [OpenBSM](http://www.trustedbsd.org/openbsm.html).  Collected event data
@@ -31,7 +31,7 @@ The documentation has been moved to the [Zeek Agent
 Wiki](https://github.com/zeek/zeek-agent/wiki), and contains
 guides on building, configuring, and extending the Zeek Agent project.
 
-For convenience, use following links to build and configure Zeek Agent:
+For convenience, use the following links to build and configure Zeek Agent:
 - [Build Guide](https://github.com/zeek/zeek-agent/wiki/Build-Guide)
 - [Configuration Guide](https://github.com/zeek/zeek-agent/wiki/Configuration-Guide)
 


### PR DESCRIPTION
This PR updates`README` file with the latest information on event tables which were added in [PR#67](https://github.com/zeek/zeek-agent/pull/67), [PR#68](https://github.com/zeek/zeek-agent/pull/68), and [PR#69](https://github.com/zeek/zeek-agent/pull/69). We still need to update wiki though with the correct build and configuration guide. 