### PR TITLE
Announce IP addresses of the endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ function(zeekAgent)
 
       src/queryscheduler.h
       src/queryscheduler.cpp
+
+      src/utils.h
+      src/utils.cpp
     )
 
     target_link_libraries("${target_name}" PRIVATE

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,51 @@
+#include "utils.h"
+#include "logger.h"
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <arpa/inet.h>
+#include <cerrno>
+#include <cstring>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#endif
+
+namespace zeek {
+std::vector<std::string> getHostIPAddrs() {
+  std::vector<std::string> ip_addrs;
+
+#if defined(__linux__) || defined(__APPLE__)
+  ifaddrs *ifaddrs = nullptr;
+  if (auto err = getifaddrs(&ifaddrs)) {
+    getLogger().logMessage(IZeekLogger::Severity::Error,
+                           "Failed to get IP addresses of the host " +
+                               std::string(strerror(errno)));
+    return {};
+  }
+
+  for (auto *ifa = ifaddrs; ifa; ifa = ifa->ifa_next) {
+    if (!ifa->ifa_addr || (ifa->ifa_flags & IFF_LOOPBACK)) {
+      continue;
+    }
+
+    if (ifa->ifa_addr->sa_family == AF_INET) {
+      auto addr =
+          reinterpret_cast<struct sockaddr_in *>(ifa->ifa_addr)->sin_addr;
+      char addressBuffer[INET_ADDRSTRLEN];
+      inet_ntop(AF_INET, &addr, addressBuffer, INET_ADDRSTRLEN);
+      ip_addrs.push_back(addressBuffer);
+    } else if (ifa->ifa_addr->sa_family == AF_INET6) {
+      auto addr =
+          reinterpret_cast<struct sockaddr_in6 *>(ifa->ifa_addr)->sin6_addr;
+      char addressBuffer[INET6_ADDRSTRLEN];
+      inet_ntop(AF_INET6, &addr, addressBuffer, INET6_ADDRSTRLEN);
+      ip_addrs.push_back(addressBuffer);
+    }
+  }
+
+  freeifaddrs(ifaddrs);
+#endif
+
+  return ip_addrs;
+}
+} // namespace zeek

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace zeek {
+/// \brief Get ip addresses of this host
+/// \return A vector of ip addresses strings
+std::vector<std::string> getHostIPAddrs();
+} // namespace zeek


### PR DESCRIPTION
To correlate Zeek Agent's socket events with Zeek network flows, we need IP addresses of the currently connected host. This PR updates the announce message to include IP addresses of the host in the message. Also, I fixed a repeated branch bug.